### PR TITLE
[AA-1229] - Fix for BulkLoad and Learning Standards progress bar not showing the correct progress 

### DIFF
--- a/Web-Gateway/nginx.conf
+++ b/Web-Gateway/nginx.conf
@@ -55,5 +55,29 @@ http {
             proxy_set_header X-Forwarded-Port 5002;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        }
+
+        location /productionLearningStandardsHub {
+            proxy_pass http://adminapp/productionLearningStandardsHub;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Forwarded-Port 5002;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_cache_bypass $http_upgrade;
+       }
+
+        location /bulkUploadHub {
+            proxy_pass http://adminapp/bulkUploadHub;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Forwarded-Port 5002;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_cache_bypass $http_upgrade;
+       }
    }
 }

--- a/Web-Ods-AdminApp/Dockerfile
+++ b/Web-Ods-AdminApp/Dockerfile
@@ -6,7 +6,7 @@
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-alpine
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
 
-ENV VERSION="2.1.0-pre0144"
+ENV VERSION="2.1.0-pre0170"
 
 WORKDIR /app
 COPY appsettings.template.json /app/appsettings.template.json


### PR DESCRIPTION
**Description**
- Added location configurations for signalr hubs (for both LearningStandards and BulkUpload) to handle the handshaking process with the help of additional "Upgrade" and "Connection" headers.

**Context**
According to [this article](https://medium.com/@alm.ozdmr/deployment-of-signalr-with-nginx-daf392cf2b93) where the author encountered a similar issue, in order to create a WebSocket connection from scratch, a new location configuration with the connection header as “upgrade” is needed.
The added configurations for both the signalr hubs seems to solve "the progress bar being stuck" issue.