### PR TITLE
[AA-1243] - Evaluate whether *clean.ps1 scripts should use the -f option

### DIFF
--- a/shared-instance-env-clean.ps1
+++ b/shared-instance-env-clean.ps1
@@ -23,6 +23,6 @@ docker-compose -f .\compose-shared-instance-env-build.yml down -v --remove-orpha
 
     $exists = (&docker images -q $_)
     if ($exists) {
-        docker rmi $_
+        docker rmi -f $_
     }
 }


### PR DESCRIPTION
**Description**

Use the -f option with rmi to untag and delete an image even if the image being referenced by running containers. This also makes shared-instance-env-clean.ps1 similar to the sandbox counterpart and follows the documentation.