### PR TITLE
[AA-1244] Revert the inclusion of environment variable ODS_ADMIN_APP_TAG

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,6 @@ POPULATED_KEY=<populated template key>
 POPULATED_SECRET=<populated template secret>
 POSTGRES_USER=<default postgres database user>
 POSTGRES_PASSWORD=<password for default postgres user>
-TAG=<version tag of the ODS/API images>
-
-# The following are only needed for Admin App
-ODS_ADMIN_APP_TAG=<version tag of the ods-admin-app image>
+TAG=<image tag version>
+# The following is only needed for Admin App
 ENCRYPTION_KEY=<base64-encoded 256-bit key>

--- a/README.md
+++ b/README.md
@@ -77,10 +77,8 @@ POPULATED_KEY=<populated template key>
 POPULATED_SECRET=<populated template secret>
 POSTGRES_USER=<default postgres database user>
 POSTGRES_PASSWORD=<password for default postgres user>
-TAG=<version tag of the ODS/API images>
-
+TAG=<image tag version>
 # The following are only needed for Admin App
-ODS_ADMIN_APP_TAG=<version tag of the ods-admin-app image>
 ENCRYPTION_KEY=<base64-encoded 256-bit key>
 ```
 

--- a/compose-shared-instance-env.yml
+++ b/compose-shared-instance-env.yml
@@ -64,7 +64,7 @@ services:
     container_name: ed-fi-ods-api
 
   adminapp:
-    image: edfialliance/ods-admin-app:${ODS_ADMIN_APP_TAG}
+    image: edfialliance/ods-admin-app:${TAG}
     environment:
       POSTGRES_USER: "${POSTGRES_USER}"
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"


### PR DESCRIPTION
PR #45 introduced an environment variable ODS_ADMIN_APP_TAG so that Admin App could version separately from the TAG of Platform images, **but after discussion with the Platform team, that was identified as unnecessary**. Instead, end users can use tags to identify specific versions (V1) or the latest incremental versions (latest), etc, so a single TAG environment variable is sufficient.

This simply reverts the change found in #45 back to a single TAG.

**Note to reviewer:** This PR was defined to merge into the admin-app branch. If that has already merged to main, then this PR can simply be updated to merge to main instead.