### PR TITLE
[AA-1239] - Display external API URLs under Docker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,4 +9,5 @@ POSTGRES_USER=<default postgres database user>
 POSTGRES_PASSWORD=<password for default postgres user>
 TAG=<image tag version>
 # The following is only needed for Admin App
+API_EXTERNAL_URL=<ods api url>
 ENCRYPTION_KEY=<base64-encoded 256-bit key>

--- a/Web-Ods-AdminApp/README.md
+++ b/Web-Ods-AdminApp/README.md
@@ -20,6 +20,7 @@ The only supported image at this time is an Alpine-based implementation.
 ```none
 ADMIN_DB=<container-resolved name of the PostgreSQL instance containing the Admin and Security databases>
 API_MODE=<mode of api>
+API_EXTERNAL_URL=<ods api url>
 ENCRYPTION_KEY=<256 bit key suitable for AES encryption>
 LOGS_FOLDER=<path to store the logs file>
 ODS_DB=<container-resolved name of the PostgreSQL instance containing the ODS database>

--- a/Web-Ods-AdminApp/appsettings.template.json
+++ b/Web-Ods-AdminApp/appsettings.template.json
@@ -6,6 +6,7 @@
       "XsdFolder": "/app/Schema",
       "DefaultOdsInstance": "EdFi ODS",
       "ProductionApiUrl": "http://api",
+      "ApiExternalUrl" : "$API_EXTERNAL_URL",
       "SystemManagedSqlServer": "true",
       "DbSetupEnabled": "false",
       "SecurityMetadataCacheTimeoutMinutes": "0",

--- a/compose-shared-instance-env-build.yml
+++ b/compose-shared-instance-env-build.yml
@@ -81,6 +81,7 @@ services:
       ODS_DB: db-ods
       ADMIN_DB: db-admin
       API_MODE: "SharedInstance"
+      API_EXTERNAL_URL: "${API_EXTERNAL_URL}"
       ENCRYPTION_KEY: "${ENCRYPTION_KEY}"
     volumes:
       - ${LOGS_FOLDER}:/app/logs

--- a/compose-shared-instance-env.yml
+++ b/compose-shared-instance-env.yml
@@ -71,6 +71,7 @@ services:
       ODS_DB: db-ods
       ADMIN_DB: db-admin
       API_MODE: "SharedInstance"
+      API_EXTERNAL_URL: "${API_EXTERNAL_URL}"
       ENCRYPTION_KEY: "${ENCRYPTION_KEY}"
     volumes:
       - ${LOGS_FOLDER}:/app/logs


### PR DESCRIPTION
**Description**

**NOTE: This PR is a companion of the  [Admin App counterpart](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-AdminApp/pull/136)**

Added env variable for ApiExternalUrl appsetting to display the actual ods api url for admin app related features instead of the docker environment api url.