### PR TITLE
[ODS-4790] await both databases during admin app startup

### DIFF
--- a/Web-Ods-AdminApp/run.sh
+++ b/Web-Ods-AdminApp/run.sh
@@ -6,17 +6,19 @@
 
 envsubst < /app/appsettings.template.json > /app/appsettings.json
 
-until PGPASSWORD=$POSTGRES_PASSWORD psql -h $ODS_DB -U $POSTGRES_USER -c '\q'; 
+until PGPASSWORD=$POSTGRES_PASSWORD psql -h $ODS_DB -U $POSTGRES_USER -c '\q';
 do
-  >&2 echo "Postgres is unavailable - sleeping"
+  >&2 echo "ODS Postgres is unavailable - sleeping"
   sleep 10
 done
-  
+
+until PGPASSWORD=$POSTGRES_PASSWORD psql -h $ADMIN_DB -U $POSTGRES_USER -c '\q';
+do
+  >&2 echo "Admin Postgres is unavailable - sleeping"
+  sleep 10
+done
+
 >&2 echo "Postgres is up - executing command"
 exec $cmd
-
-# Extra sleep giving a few seconds for initial AdminApp db migrations
-# to run in the admin container
-sleep 10
 
 dotnet EdFi.Ods.AdminApp.Web.dll


### PR DESCRIPTION
This addresses feedback in #47 regarding the need to wait for *both* databases to start up in Web-Ods-AdminApp/run.sh requested here: https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Docker/pull/47#discussion_r563943699
