### PR TITLE
[ODS-5038] Resolve build errors caused by dependence on outdated packages

### DIFF
--- a/DB-Admin/Alpine/pgsql/Dockerfile
+++ b/DB-Admin/Alpine/pgsql/Dockerfile
@@ -16,7 +16,7 @@ ENV ADMINAPP_DATABASE_VERSION="2.2.0"
 
 COPY init-database.sh /docker-entrypoint-initdb.d/init-database.sh
 
-RUN apk --no-cache add dos2unix=7.4.2-r0 unzip=6.0-r8 && \
+RUN apk --no-cache add dos2unix=~7.4 unzip=~6.0 && \
     wget -O /tmp/EdFi_Admin.zip https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.Database.Admin.PostgreSQL/versions/${ADMIN_VERSION}/content && \
     wget -O /tmp/EdFi_Security.zip https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.Database.Security.PostgreSQL/versions/${SECURITY_VERSION}/content && \
     wget -O /tmp/EdFi_AdminApp_Scripts.zip https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.Suite3.ODS.AdminApp.Database/versions/${ADMINAPP_DATABASE_VERSION}/content && \

--- a/DB-ODS/Alpine/pgsql/Dockerfile
+++ b/DB-ODS/Alpine/pgsql/Dockerfile
@@ -15,7 +15,7 @@ ENV POSTGRES_DB=postgres
 
 COPY init-database.sh /docker-entrypoint-initdb.d/init-database.sh
 
-RUN apk --no-cache add unzip=6.0-r8 dos2unix=7.4.2-r0 && \
+RUN apk --no-cache add unzip=~6.0 dos2unix=~7.4 && \
     wget -O /tmp/OdsMinimalDatabase.zip https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.Suite3.Ods.Minimal.Template.PostgreSQL/versions/${MINVERSION}/content && \
     unzip -p /tmp/OdsMinimalDatabase.zip EdFi.Ods.Minimal.Template.sql > /tmp/EdFi_Ods_Minimal_Template.sql && \
     rm -f /tmp/*.zip && \

--- a/DB-Sandbox/Alpine/pgsql/Dockerfile
+++ b/DB-Sandbox/Alpine/pgsql/Dockerfile
@@ -16,7 +16,7 @@ ENV POSTGRES_DB=postgres
 
 COPY init-database.sh /docker-entrypoint-initdb.d/init-database.sh
 
-RUN apk --no-cache add unzip=6.0-r8 dos2unix=7.4.2-r0 && \
+RUN apk --no-cache add unzip=~6.0 dos2unix=~7.4 && \
     wget -O /tmp/OdsMinimalDatabase.zip https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.Suite3.Ods.Minimal.Template.PostgreSQL/versions/${MINVERSION}/content && \
     wget -O /tmp/OdsPopulatedDatabase.zip https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.Suite3.Ods.Populated.Template.PostgreSQL/versions/${POPULVERSION}/content && \
     unzip -p /tmp/OdsMinimalDatabase.zip EdFi.Ods.Minimal.Template.sql > /tmp/EdFi_Ods_Minimal_Template.sql && \

--- a/Web-Ods-AdminApp/Alpine/mssql/Dockerfile
+++ b/Web-Ods-AdminApp/Alpine/mssql/Dockerfile
@@ -21,7 +21,7 @@ COPY appsettings.template.json /app/appsettings.template.json
 COPY run.sh /app/run.sh
 COPY log4net.config /app/log4net.txt
 
-RUN apk --no-cache add unzip=6.0-r8 dos2unix=7.4.2-r0 bash=5.1.0-r0 gettext=0.20.2-r2 postgresql-client=13.2-r0 jq=1.6-r1 icu=67.1-r2 && \
+RUN apk --no-cache add unzip=~6.0 dos2unix=~7.4 bash=~5.1 gettext=~0.20 postgresql-client=~13.3 jq=~1.6 icu=~67.1 && \
     wget -O /app/AdminApp.zip https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.Suite3.ODS.AdminApp.Web/versions/${VERSION}/content && \
     unzip /app/AdminApp.zip -d /app && \
     rm -f /app/AdminApp.zip && \

--- a/Web-Ods-AdminApp/Alpine/pgsql/Dockerfile
+++ b/Web-Ods-AdminApp/Alpine/pgsql/Dockerfile
@@ -21,7 +21,7 @@ COPY appsettings.template.json /app/appsettings.template.json
 COPY run.sh /app/run.sh
 COPY log4net.config /app/log4net.txt
 
-RUN apk --no-cache add unzip=6.0-r8 dos2unix=7.4.2-r0 bash=5.1.0-r0 gettext=0.20.2-r2 postgresql-client=13.2-r0 jq=1.6-r1 icu=67.1-r2 && \
+RUN apk --no-cache add unzip=~6.0 dos2unix=~7.4 bash=~5.1 gettext=~0.20 postgresql-client=~13.3 jq=~1.6 icu=~67.1 && \
     wget -O /app/AdminApp.zip  https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.Suite3.ODS.AdminApp.Web/versions/${VERSION}/content && \
     unzip /app/AdminApp.zip -d /app && \
     rm -f /app/AdminApp.zip && \

--- a/Web-Ods-Api/Alpine/mssql/Dockerfile
+++ b/Web-Ods-Api/Alpine/mssql/Dockerfile
@@ -17,7 +17,7 @@ COPY appsettings.template.json /app/appsettings.template.json
 COPY run.sh /app/run.sh
 COPY log4net.config /app/log4net.txt
 
-RUN apk --no-cache add unzip=6.0-r8 dos2unix=7.4.2-r0 bash=5.1.0-r0 gettext=0.20.2-r2 icu=67.1-r2 && \
+RUN apk --no-cache add unzip=~6.0 dos2unix=~7.4 bash=~5.1 gettext=~0.20 icu=~67.1 && \
     wget -O /app/WebApi.zip  https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.Suite3.Ods.WebApi/versions/${VERSION}/content && \
     unzip /app/WebApi.zip -d /app && \
     rm -f /app/WebApi.zip && \

--- a/Web-Ods-Api/Alpine/pgsql/Dockerfile
+++ b/Web-Ods-Api/Alpine/pgsql/Dockerfile
@@ -21,7 +21,7 @@ COPY appsettings.template.json /app/appsettings.template.json
 COPY run.sh /app/run.sh
 COPY log4net.config /app/log4net.txt
 
-RUN apk --no-cache add unzip=6.0-r8 dos2unix=7.4.2-r0 bash=5.1.0-r0 gettext=0.20.2-r2 postgresql-client=13.2-r0 icu=67.1-r2 && \
+RUN apk --no-cache add unzip=~6.0 dos2unix=~7.4 bash=~5.1 gettext=~0.20 postgresql-client=~13.3 icu=~67.1 && \
     wget -O /app/WebApi.zip https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.Suite3.Ods.WebApi/versions/${VERSION}/content && \
     unzip /app/WebApi.zip -d /app && \
     rm -f /app/WebApi.zip && \

--- a/Web-Sandbox-Admin/Alpine/mssql/Dockerfile
+++ b/Web-Sandbox-Admin/Alpine/mssql/Dockerfile
@@ -22,7 +22,7 @@ COPY appsettings.template.json /app/appsettings.template.json
 COPY run.sh /app/run.sh
 COPY log4net.config /app/log4net.txt
 
-RUN apk --no-cache add unzip=6.0-r8 dos2unix=7.4.2-r0 bash=5.1.0-r0 gettext=0.20.2-r2 icu=67.1-r2 && \
+RUN apk --no-cache add unzip=~6.0 dos2unix=~7.4 bash=~5.1 gettext=~0.20 icu=~67.1 && \
     wget -O /app/SandboxAdmin.zip https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.Suite3.Ods.SandboxAdmin/versions/${VERSION}/content && \
     unzip /app/SandboxAdmin.zip -d /app && \
     rm -f /app/SandboxAdmin.zip && \

--- a/Web-Sandbox-Admin/Alpine/pgsql/Dockerfile
+++ b/Web-Sandbox-Admin/Alpine/pgsql/Dockerfile
@@ -22,7 +22,7 @@ COPY appsettings.template.json /app/appsettings.template.json
 COPY run.sh /app/run.sh
 COPY log4net.config /app/log4net.txt
 
-RUN apk --no-cache add unzip=6.0-r8 dos2unix=7.4.2-r0 bash=5.1.0-r0 gettext=0.20.2-r2 postgresql-client=13.2-r0 icu=67.1-r2 && \
+RUN apk --no-cache add unzip=~6.0 dos2unix=~7.4 bash=~5.1 gettext=~0.20 postgresql-client=~13.3 icu=~67.1 && \
     wget -O /app/SandboxAdmin.zip https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.Suite3.Ods.SandboxAdmin/versions/${VERSION}/content && \
     unzip /app/SandboxAdmin.zip -d /app && \
     rm -f /app/SandboxAdmin.zip && \

--- a/Web-SwaggerUI/Alpine/Dockerfile
+++ b/Web-SwaggerUI/Alpine/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /app
 COPY appsettings.template.json /app/appsettings.template.json
 COPY run.sh /app/run.sh
 
-RUN apk --no-cache add unzip=6.0-r8 dos2unix=7.4.2-r0 bash=5.1.0-r0 gettext=0.20.2-r2 icu=67.1-r2 && \
+RUN apk --no-cache add unzip=~6.0 dos2unix=~7.4 bash=~5.1 gettext=~0.20 icu=~67.1 && \
     wget -O /app/SwaggerUI.zip https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.Suite3.Ods.SwaggerUI/versions/${VERSION}/content && \
     unzip /app/SwaggerUI.zip -d /app && \
     rm -f /app/SwaggerUI.zip && \


### PR DESCRIPTION
I have tested the Admin App / API integration with tag pre-aa. I am unable to build the images locally because I get an error when downloading packages from Azure; appears to be problem with my Internet connection provider, as it occurs on both my work and home computers. The pre-aa build process does not cover the Sandbox components, so I have not been able to test them. Someone who can build locally should startup the sandbox environment from this branch to confirm that everything is working.