### PR TITLE
[AA-1358] - Add Docker Healthcheck for Admin App

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,8 @@ ENCRYPTION_KEY=<base64-encoded 256-bit key>
 SQLSERVER_DATASOURCE=<DNS or IP Address of the SQL Server Instance, i.e. sql.somedns.org or 10.1.5.9,1433
 SQLSERVER_USER=<SQL Username with access to SQL Server Ed-Fi databases, edfiadmin>
 SQLSERVER_PASSWORD=<SQL Password for the SQLSERVER_USER with access to SQL Server Ed-Fi databases, password123!>
+
+# The following can be used for to specify a healthcheck test command for admin app.
+# To do nothing set it to "/bin/true"
+# To use the Admin App healthcheck endpoint use "curl http://<ADMINAPP_VIRTUAL_NAME:-adminapp>/health"
+ADMINAPP_HEALTHCHECK_TEST=/bin/true

--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,9 @@ SQLSERVER_DATASOURCE=<DNS or IP Address of the SQL Server Instance, i.e. sql.som
 SQLSERVER_USER=<SQL Username with access to SQL Server Ed-Fi databases, edfiadmin>
 SQLSERVER_PASSWORD=<SQL Password for the SQLSERVER_USER with access to SQL Server Ed-Fi databases, password123!>
 
-# The following can be used for to specify a healthcheck test command for admin app.
-# To do nothing set it to "/bin/true"
-# To use the Admin App healthcheck endpoint use "curl http://<ADMINAPP_VIRTUAL_NAME:-adminapp>/health"
-ADMINAPP_HEALTHCHECK_TEST=/bin/true
+# The following variable (ADMINAPP_HEALTHCHECK_TEST) needs to be set to specify a healthcheck test for admin app.
+# (Recommended) To use the default internal Admin App healthcheck endpoint, set the variable as follows
+# ADMINAPP_HEALTHCHECK_TEST="curl -f http://${ADMINAPP_VIRTUAL_NAME}/health"
+# To disable the healthcheck, set the variable as follows
+# ADMINAPP_HEALTHCHECK_TEST=/bin/true
+# To add a custom health check, consult the documentation at https://docs.docker.com/compose/compose-file/compose-file-v3/#healthcheck

--- a/.env.example
+++ b/.env.example
@@ -22,9 +22,9 @@ SQLSERVER_DATASOURCE=<DNS or IP Address of the SQL Server Instance, i.e. sql.som
 SQLSERVER_USER=<SQL Username with access to SQL Server Ed-Fi databases, edfiadmin>
 SQLSERVER_PASSWORD=<SQL Password for the SQLSERVER_USER with access to SQL Server Ed-Fi databases, password123!>
 
-# The following variable (ADMINAPP_HEALTHCHECK_TEST) needs to be set to specify a healthcheck test for admin app.
-# (Recommended) To use the default internal Admin App healthcheck endpoint, set the variable as follows
-# ADMINAPP_HEALTHCHECK_TEST="curl -f http://${ADMINAPP_VIRTUAL_NAME}/health"
-# To disable the healthcheck, set the variable as follows
+# The following needs to be set to specify a healthcheck test for admin app.
+# RECOMMENDED: To use the default internal Admin App healthcheck endpoint, set the variable as follows:
+ADMINAPP_HEALTHCHECK_TEST="curl -f http://${ADMINAPP_VIRTUAL_NAME}/health"
+#  To disable the healthcheck, remove the above and instead set the variable as follows:
 # ADMINAPP_HEALTHCHECK_TEST=/bin/true
-# To add a custom health check, consult the documentation at https://docs.docker.com/compose/compose-file/compose-file-v3/#healthcheck
+#  To add a custom health check, consult the documentation at https://docs.docker.com/compose/compose-file/compose-file-v3/#healthcheck

--- a/Compose/mssql/compose-shared-instance-env-build.yml
+++ b/Compose/mssql/compose-shared-instance-env-build.yml
@@ -54,7 +54,7 @@ services:
       SQLSERVER_DATASOURCE: "${SQLSERVER_DATASOURCE:-host.docker.internal}"
       SQLSERVER_USER: "${SQLSERVER_USER}"
       SQLSERVER_PASSWORD: "${SQLSERVER_PASSWORD}"
-      ADMINAPP_HEALTHCHECK_TEST: ${ADMINAPP_HEALTHCHECK_TEST}
+      ADMINAPP_HEALTHCHECK_TEST: ${ADMINAPP_HEALTHCHECK_TEST?Please consult env.example to set the Admin App healthcheck test}
     volumes:
       - ${LOGS_FOLDER}:/app/logs
       - adminapp-bulk-hashcache:/app/BulkUploadHashCache
@@ -65,9 +65,7 @@ services:
     hostname: adminapp
     container_name: ed-fi-ods-adminapp
     healthcheck:
-      test: "${ADMINAPP_HEALTHCHECK_TEST:-curl http://${ADMINAPP_VIRTUAL_NAME:-adminapp}/health}"
-      interval: "15s"
-      timeout: "10s"
+      test: $$ADMINAPP_HEALTHCHECK_TEST
       start_period: "60s"
       retries: 3
 

--- a/Compose/mssql/compose-shared-instance-env-build.yml
+++ b/Compose/mssql/compose-shared-instance-env-build.yml
@@ -54,6 +54,7 @@ services:
       SQLSERVER_DATASOURCE: "${SQLSERVER_DATASOURCE:-host.docker.internal}"
       SQLSERVER_USER: "${SQLSERVER_USER}"
       SQLSERVER_PASSWORD: "${SQLSERVER_PASSWORD}"
+      ADMINAPP_HEALTHCHECK_TEST: ${ADMINAPP_HEALTHCHECK_TEST}
     volumes:
       - ${LOGS_FOLDER}:/app/logs
       - adminapp-bulk-hashcache:/app/BulkUploadHashCache
@@ -63,6 +64,12 @@ services:
     restart: always
     hostname: adminapp
     container_name: ed-fi-ods-adminapp
+    healthcheck:
+      test: "${ADMINAPP_HEALTHCHECK_TEST:-curl http://${ADMINAPP_VIRTUAL_NAME:-adminapp}/health}"
+      interval: "15s"
+      timeout: "10s"
+      start_period: "60s"
+      retries: 3
 
 volumes:
   adminapp-bulk-hashcache:

--- a/Compose/mssql/compose-shared-instance-env.yml
+++ b/Compose/mssql/compose-shared-instance-env.yml
@@ -48,6 +48,7 @@ services:
       SQLSERVER_DATASOURCE: "${SQLSERVER_DATASOURCE:-host.docker.internal}"
       SQLSERVER_USER: "${SQLSERVER_USER}"
       SQLSERVER_PASSWORD: "${SQLSERVER_PASSWORD}"
+      ADMINAPP_HEALTHCHECK_TEST: ${ADMINAPP_HEALTHCHECK_TEST}
     volumes:
       - ${LOGS_FOLDER}:/app/logs
       - adminapp-bulk-hashcache:/app/BulkUploadHashCache
@@ -57,6 +58,12 @@ services:
     restart: always
     hostname: adminapp
     container_name: ed-fi-ods-adminapp
+    healthcheck:
+      test: "${ADMINAPP_HEALTHCHECK_TEST:-curl http://${ADMINAPP_VIRTUAL_NAME:-adminapp}/health}"
+      interval: "15s"
+      timeout: "10s"
+      start_period: "60s"
+      retries: 3
 
 volumes:
   adminapp-bulk-hashcache:

--- a/Compose/mssql/compose-shared-instance-env.yml
+++ b/Compose/mssql/compose-shared-instance-env.yml
@@ -48,7 +48,7 @@ services:
       SQLSERVER_DATASOURCE: "${SQLSERVER_DATASOURCE:-host.docker.internal}"
       SQLSERVER_USER: "${SQLSERVER_USER}"
       SQLSERVER_PASSWORD: "${SQLSERVER_PASSWORD}"
-      ADMINAPP_HEALTHCHECK_TEST: ${ADMINAPP_HEALTHCHECK_TEST}
+      ADMINAPP_HEALTHCHECK_TEST: ${ADMINAPP_HEALTHCHECK_TEST?Please consult env.example to set the Admin App healthcheck test}
     volumes:
       - ${LOGS_FOLDER}:/app/logs
       - adminapp-bulk-hashcache:/app/BulkUploadHashCache
@@ -59,9 +59,7 @@ services:
     hostname: adminapp
     container_name: ed-fi-ods-adminapp
     healthcheck:
-      test: "${ADMINAPP_HEALTHCHECK_TEST:-curl http://${ADMINAPP_VIRTUAL_NAME:-adminapp}/health}"
-      interval: "15s"
-      timeout: "10s"
+      test: $$ADMINAPP_HEALTHCHECK_TEST
       start_period: "60s"
       retries: 3
 

--- a/Compose/pgsql/compose-shared-instance-env-build.yml
+++ b/Compose/pgsql/compose-shared-instance-env-build.yml
@@ -86,7 +86,7 @@ services:
       ENCRYPTION_KEY: "${ENCRYPTION_KEY}"
       ADMINAPP_VIRTUAL_NAME: "${ADMINAPP_VIRTUAL_NAME:-adminapp}"
       API_INTERNAL_URL: "https://nginx/${ODS_VIRTUAL_NAME:-api}"
-      ADMINAPP_HEALTHCHECK_TEST: ${ADMINAPP_HEALTHCHECK_TEST}
+      ADMINAPP_HEALTHCHECK_TEST: ${ADMINAPP_HEALTHCHECK_TEST?Please consult env.example to set the Admin App healthcheck test}
     volumes:
       - ${LOGS_FOLDER}:/app/logs
       - adminapp-bulk-hashcache:/app/BulkUploadHashCache
@@ -99,9 +99,7 @@ services:
     hostname: adminapp
     container_name: ed-fi-ods-adminapp
     healthcheck:
-      test: "${ADMINAPP_HEALTHCHECK_TEST:-curl http://${ADMINAPP_VIRTUAL_NAME:-adminapp}/health}"
-      interval: "15s"
-      timeout: "10s"
+      test: $$ADMINAPP_HEALTHCHECK_TEST
       start_period: "60s"
       retries: 3
 

--- a/Compose/pgsql/compose-shared-instance-env-build.yml
+++ b/Compose/pgsql/compose-shared-instance-env-build.yml
@@ -86,6 +86,7 @@ services:
       ENCRYPTION_KEY: "${ENCRYPTION_KEY}"
       ADMINAPP_VIRTUAL_NAME: "${ADMINAPP_VIRTUAL_NAME:-adminapp}"
       API_INTERNAL_URL: "https://nginx/${ODS_VIRTUAL_NAME:-api}"
+      ADMINAPP_HEALTHCHECK_TEST: ${ADMINAPP_HEALTHCHECK_TEST}
     volumes:
       - ${LOGS_FOLDER}:/app/logs
       - adminapp-bulk-hashcache:/app/BulkUploadHashCache
@@ -97,6 +98,12 @@ services:
     restart: always
     hostname: adminapp
     container_name: ed-fi-ods-adminapp
+    healthcheck:
+      test: "${ADMINAPP_HEALTHCHECK_TEST:-curl http://${ADMINAPP_VIRTUAL_NAME:-adminapp}/health}"
+      interval: "15s"
+      timeout: "10s"
+      start_period: "60s"
+      retries: 3
 
   pb-admin:
     image: pgbouncer/pgbouncer

--- a/Compose/pgsql/compose-shared-instance-env.yml
+++ b/Compose/pgsql/compose-shared-instance-env.yml
@@ -76,6 +76,7 @@ services:
       ENCRYPTION_KEY: "${ENCRYPTION_KEY}"
       ADMINAPP_VIRTUAL_NAME: "${ADMINAPP_VIRTUAL_NAME:-adminapp}"
       API_INTERNAL_URL: "https://nginx/${ODS_VIRTUAL_NAME:-api}"
+      ADMINAPP_HEALTHCHECK_TEST: ${ADMINAPP_HEALTHCHECK_TEST}
     volumes:
       - ${LOGS_FOLDER}:/app/logs
       - adminapp-bulk-hashcache:/app/BulkUploadHashCache
@@ -87,6 +88,12 @@ services:
     restart: always
     hostname: adminapp
     container_name: ed-fi-ods-adminapp
+    healthcheck:
+      test: "${ADMINAPP_HEALTHCHECK_TEST:-curl http://${ADMINAPP_VIRTUAL_NAME:-adminapp}/health}"
+      interval: "15s"
+      timeout: "10s"
+      start_period: "60s"
+      retries: 3
 
   pb-admin:
     image: pgbouncer/pgbouncer

--- a/Compose/pgsql/compose-shared-instance-env.yml
+++ b/Compose/pgsql/compose-shared-instance-env.yml
@@ -76,7 +76,7 @@ services:
       ENCRYPTION_KEY: "${ENCRYPTION_KEY}"
       ADMINAPP_VIRTUAL_NAME: "${ADMINAPP_VIRTUAL_NAME:-adminapp}"
       API_INTERNAL_URL: "https://nginx/${ODS_VIRTUAL_NAME:-api}"
-      ADMINAPP_HEALTHCHECK_TEST: ${ADMINAPP_HEALTHCHECK_TEST}
+      ADMINAPP_HEALTHCHECK_TEST: ${ADMINAPP_HEALTHCHECK_TEST?Please consult env.example to set the Admin App healthcheck test}
     volumes:
       - ${LOGS_FOLDER}:/app/logs
       - adminapp-bulk-hashcache:/app/BulkUploadHashCache
@@ -89,9 +89,7 @@ services:
     hostname: adminapp
     container_name: ed-fi-ods-adminapp
     healthcheck:
-      test: "${ADMINAPP_HEALTHCHECK_TEST:-curl http://${ADMINAPP_VIRTUAL_NAME:-adminapp}/health}"
-      interval: "15s"
-      timeout: "10s"
+      test: $$ADMINAPP_HEALTHCHECK_TEST
       start_period: "60s"
       retries: 3
 

--- a/Web-Ods-AdminApp/Alpine/mssql/Dockerfile
+++ b/Web-Ods-AdminApp/Alpine/mssql/Dockerfile
@@ -21,7 +21,7 @@ COPY appsettings.template.json /app/appsettings.template.json
 COPY run.sh /app/run.sh
 COPY log4net.config /app/log4net.txt
 
-RUN apk --no-cache add unzip=~6.0 dos2unix=~7.4 bash=~5.1 gettext=~0.21 postgresql-client=~13.4 jq=~1.6 icu=~67.1 && \
+RUN apk --no-cache add unzip=~6.0 dos2unix=~7.4 bash=~5.1 gettext=~0.21 postgresql-client=~13.4 jq=~1.6 icu=~67.1 curl && \
     wget -O /app/AdminApp.zip https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.Suite3.ODS.AdminApp.Web/versions/${VERSION}/content && \
     unzip /app/AdminApp.zip -d /app && \
     rm -f /app/AdminApp.zip && \

--- a/Web-Ods-AdminApp/Alpine/mssql/Dockerfile
+++ b/Web-Ods-AdminApp/Alpine/mssql/Dockerfile
@@ -21,7 +21,7 @@ COPY appsettings.template.json /app/appsettings.template.json
 COPY run.sh /app/run.sh
 COPY log4net.config /app/log4net.txt
 
-RUN apk --no-cache add unzip=~6.0 dos2unix=~7.4 bash=~5.1 gettext=~0.21 postgresql-client=~13.4 jq=~1.6 icu=~67.1 curl && \
+RUN apk --no-cache add unzip=~6.0 dos2unix=~7.4 bash=~5.1 gettext=~0.21 postgresql-client=~13.4 jq=~1.6 icu=~67.1 curl=~7.79 && \
     wget -O /app/AdminApp.zip https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.Suite3.ODS.AdminApp.Web/versions/${VERSION}/content && \
     unzip /app/AdminApp.zip -d /app && \
     rm -f /app/AdminApp.zip && \

--- a/Web-Ods-AdminApp/Alpine/mssql/Dockerfile
+++ b/Web-Ods-AdminApp/Alpine/mssql/Dockerfile
@@ -6,7 +6,7 @@
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-alpine
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
 
-ENV VERSION="2.2.1"
+ENV VERSION="2.4.0-pre0002"
 ENV POSTGRES_PORT=5432
 ENV PGBOUNCER_LISTEN_PORT=6432
 ENV ADMINAPP_VIRTUAL_NAME=adminapp

--- a/Web-Ods-AdminApp/Alpine/pgsql/Dockerfile
+++ b/Web-Ods-AdminApp/Alpine/pgsql/Dockerfile
@@ -21,7 +21,7 @@ COPY appsettings.template.json /app/appsettings.template.json
 COPY run.sh /app/run.sh
 COPY log4net.config /app/log4net.txt
 
-RUN apk --no-cache add unzip=~6.0 dos2unix=~7.4 bash=~5.1 gettext=~0.21 postgresql-client=~13.4 jq=~1.6 icu=~67.1 curl && \
+RUN apk --no-cache add unzip=~6.0 dos2unix=~7.4 bash=~5.1 gettext=~0.21 postgresql-client=~13.4 jq=~1.6 icu=~67.1 curl=~7.79 && \
     wget -O /app/AdminApp.zip  https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.Suite3.ODS.AdminApp.Web/versions/${VERSION}/content && \
     unzip /app/AdminApp.zip -d /app && \
     rm -f /app/AdminApp.zip && \

--- a/Web-Ods-AdminApp/Alpine/pgsql/Dockerfile
+++ b/Web-Ods-AdminApp/Alpine/pgsql/Dockerfile
@@ -21,7 +21,7 @@ COPY appsettings.template.json /app/appsettings.template.json
 COPY run.sh /app/run.sh
 COPY log4net.config /app/log4net.txt
 
-RUN apk --no-cache add unzip=~6.0 dos2unix=~7.4 bash=~5.1 gettext=~0.21 postgresql-client=~13.4 jq=~1.6 icu=~67.1 && \
+RUN apk --no-cache add unzip=~6.0 dos2unix=~7.4 bash=~5.1 gettext=~0.21 postgresql-client=~13.4 jq=~1.6 icu=~67.1 curl && \
     wget -O /app/AdminApp.zip  https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.Suite3.ODS.AdminApp.Web/versions/${VERSION}/content && \
     unzip /app/AdminApp.zip -d /app && \
     rm -f /app/AdminApp.zip && \

--- a/Web-Ods-AdminApp/Alpine/pgsql/Dockerfile
+++ b/Web-Ods-AdminApp/Alpine/pgsql/Dockerfile
@@ -6,7 +6,7 @@
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-alpine
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
 
-ENV VERSION="2.2.1"
+ENV VERSION="2.4.0-pre0002"
 ENV POSTGRES_PORT=5432
 ENV PGBOUNCER_LISTEN_PORT=6432
 ENV ADMINAPP_VIRTUAL_NAME=adminapp


### PR DESCRIPTION
**NOTE: This PR must be merged in after the corresponding [Admin App PR](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-AdminApp/pull/240) has been merged in**
**Description**
- Added healtcheck configurations for Admin App in the shared instance docker compose files for both MSSQL and PGSQL.
- Added curl to the list of packages to install for Admin App containers since it is needed for the health check.
- Added documentation for the ADMINAPP_HEALTHCHECK_TEST environment variable.