### PR TITLE
[AA-1210] - Create separate shell script for Admin App database migrations

### DIFF
--- a/DB-Admin/Alpine/pgsql/Dockerfile
+++ b/DB-Admin/Alpine/pgsql/Dockerfile
@@ -14,7 +14,8 @@ ENV ADMIN_VERSION="5.3.154"
 ENV SECURITY_VERSION="5.3.152"
 ENV ADMINAPP_DATABASE_VERSION="2.4.0-pre0002"
 
-COPY init-database.sh /docker-entrypoint-initdb.d/init-database.sh
+COPY init-database.sh /docker-entrypoint-initdb.d/1-init-database.sh
+COPY run-adminapp-migrations.sh /docker-entrypoint-initdb.d/2-run-adminapp-migrations.sh
 
 RUN apk --no-cache add dos2unix=~7.4 unzip=~6.0 && \
     wget -O /tmp/EdFi_Admin.zip https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.Database.Admin.PostgreSQL/versions/${ADMIN_VERSION}/content && \
@@ -23,7 +24,8 @@ RUN apk --no-cache add dos2unix=~7.4 unzip=~6.0 && \
     unzip -p /tmp/EdFi_Admin.zip EdFi_Admin.sql > /tmp/EdFi_Admin.sql && \
     unzip -p /tmp/EdFi_Security.zip EdFi_Security.sql > /tmp/EdFi_Security.sql && \
     unzip /tmp/EdFi_AdminApp_Scripts.zip PgSql/* -d /tmp/AdminAppScripts/ && \
-    dos2unix /docker-entrypoint-initdb.d/init-database.sh && \
+    dos2unix /docker-entrypoint-initdb.d/1-init-database.sh && \
+    dos2unix /docker-entrypoint-initdb.d/2-run-adminapp-migrations.sh && \
     dos2unix /tmp/EdFi_Admin.sql && \
     dos2unix /tmp/EdFi_Security.sql && \
     dos2unix /tmp/AdminAppScripts/PgSql/*

--- a/DB-Admin/Alpine/pgsql/init-database.sh
+++ b/DB-Admin/Alpine/pgsql/init-database.sh
@@ -24,12 +24,3 @@ psql --no-password --username "$POSTGRES_USER" --port $POSTGRES_PORT --dbname "E
 
 echo "Loading Admin database from backup..."
 psql --no-password --username "$POSTGRES_USER" --port $POSTGRES_PORT --dbname "EdFi_Admin" --file /tmp/EdFi_Admin.sql 1> /dev/null
-
-if [ "${API_MODE,,}" = "sharedinstance" ]; then
-    # Force sorting by name following C language sort ordering, so that the sql scripts are run
-    # sequentially in the correct alphanumeric order
-    for FILE in `LANG=C ls /tmp/AdminAppScripts/PgSql/* | sort -V`
-    do
-        psql --no-password --username "$POSTGRES_USER" --port $POSTGRES_PORT --dbname "EdFi_Admin" --file $FILE 1> /dev/null
-    done
-fi

--- a/DB-Admin/Alpine/pgsql/run-adminapp-migrations.sh
+++ b/DB-Admin/Alpine/pgsql/run-adminapp-migrations.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+set -e
+set -x
+
+if [[ -z "$POSTGRES_PORT" ]]; then
+  export POSTGRES_PORT=5432
+fi
+
+if [ "${API_MODE,,}" = "sharedinstance" ]; then
+    # Force sorting by name following C language sort ordering, so that the sql scripts are run
+    # sequentially in the correct alphanumeric order
+    echo "Running Admin App database migration scripts..."
+
+    for FILE in `LANG=C ls /tmp/AdminAppScripts/PgSql/* | sort -V`
+    do
+        psql --no-password --username "$POSTGRES_USER" --port $POSTGRES_PORT --dbname "EdFi_Admin" --file $FILE 1> /dev/null
+    done
+fi


### PR DESCRIPTION
**Description**
- Moved the Admin App migration scripts conditional to its own shell script (run-adminapp-migrations.sh)
- Added docker instructions to copy the new `run-adminapp-migrations` script in the entrypoint folders and convert to unix format similar to `init-database.sh` instructions. The numbers to the names of the copied destination files ensure that `init-database.sh` is executed before `run-adminapp-migrations.sh`.