### PR TITLE
Disable shell debug

### DIFF
--- a/DB-Admin/Alpine/pgsql/init-database.sh
+++ b/DB-Admin/Alpine/pgsql/init-database.sh
@@ -5,7 +5,7 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 set -e
-set -x
+set +x
 
 if [[ -z "$POSTGRES_PORT" ]]; then
   export POSTGRES_PORT=5432

--- a/DB-Admin/Alpine/pgsql/run-adminapp-migrations.sh
+++ b/DB-Admin/Alpine/pgsql/run-adminapp-migrations.sh
@@ -5,7 +5,7 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 set -e
-set -x
+set +x
 
 if [[ -z "$POSTGRES_PORT" ]]; then
   export POSTGRES_PORT=5432

--- a/DB-ODS/Alpine/pgsql/init-database.sh
+++ b/DB-ODS/Alpine/pgsql/init-database.sh
@@ -5,7 +5,7 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 set -e
-set -x
+set +x
 
 if [[ -z "$POSTGRES_PORT" ]]; then
   export POSTGRES_PORT=5432

--- a/DB-Sandbox/Alpine/pgsql/init-database.sh
+++ b/DB-Sandbox/Alpine/pgsql/init-database.sh
@@ -5,7 +5,7 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 set -e
-set -x
+set +x
 
 if [[ -z "$POSTGRES_PORT" ]]; then
   export POSTGRES_PORT=5432

--- a/Web-Ods-AdminApp/Alpine/mssql/run.sh
+++ b/Web-Ods-AdminApp/Alpine/mssql/run.sh
@@ -5,7 +5,7 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 set -e
-set -x
+set +x
 
 envsubst < /app/appsettings.template.json > /app/temp.json
 

--- a/Web-Ods-AdminApp/Alpine/pgsql/run.sh
+++ b/Web-Ods-AdminApp/Alpine/pgsql/run.sh
@@ -5,7 +5,7 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 set -e
-set -x
+set +x
 
 envsubst < /app/appsettings.template.json > /app/temp.json
 
@@ -21,7 +21,7 @@ if [[ -z "$ODS_WAIT_POSTGRES_HOSTS" ]]; then
   export ODS_WAIT_POSTGRES_HOSTS=$ODS_POSTGRES_HOST
 fi
 
-export ODS_WAIT_POSTGRES_HOSTS_ARR=($ODS_WAIT_POSTGRES_HOSTS) 
+export ODS_WAIT_POSTGRES_HOSTS_ARR=($ODS_WAIT_POSTGRES_HOSTS)
 for HOST in ${ODS_WAIT_POSTGRES_HOSTS_ARR[@]}
 do
   until PGPASSWORD=$POSTGRES_PASSWORD psql -h $HOST -p $POSTGRES_PORT -U $POSTGRES_USER -c '\q';

--- a/Web-Ods-Api/Alpine/mssql/run.sh
+++ b/Web-Ods-Api/Alpine/mssql/run.sh
@@ -5,7 +5,7 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 set -e
-set -x
+set +x
 
 if [[ "$TPDM_ENABLED" != true ]]; then
     export Plugin__Folder="./Plugin_Disabled"

--- a/Web-Ods-Api/Alpine/pgsql/run.sh
+++ b/Web-Ods-Api/Alpine/pgsql/run.sh
@@ -5,7 +5,7 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 set -e
-set -x
+set +x
 
 if [[ "$TPDM_ENABLED" != true ]]; then
     export Plugin__Folder="./Plugin_Disabled"
@@ -18,7 +18,7 @@ if [[ -z "$ODS_WAIT_POSTGRES_HOSTS" ]]; then
   export ODS_WAIT_POSTGRES_HOSTS=$ODS_POSTGRES_HOST
 fi
 
-export ODS_WAIT_POSTGRES_HOSTS_ARR=($ODS_WAIT_POSTGRES_HOSTS) 
+export ODS_WAIT_POSTGRES_HOSTS_ARR=($ODS_WAIT_POSTGRES_HOSTS)
 for HOST in ${ODS_WAIT_POSTGRES_HOSTS_ARR[@]}
 do
   until PGPASSWORD=$POSTGRES_PASSWORD psql -h $HOST -p $POSTGRES_PORT -U $POSTGRES_USER -c '\q';

--- a/Web-Sandbox-Admin/Alpine/mssql/run.sh
+++ b/Web-Sandbox-Admin/Alpine/mssql/run.sh
@@ -5,7 +5,7 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 set -e
-set -x
+set +x
 
 envsubst < /app/appsettings.template.json > /app/appsettings.json
 

--- a/Web-Sandbox-Admin/Alpine/pgsql/run.sh
+++ b/Web-Sandbox-Admin/Alpine/pgsql/run.sh
@@ -5,7 +5,7 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 set -e
-set -x
+set +x
 
 envsubst < /app/appsettings.template.json > /app/appsettings.json
 

--- a/Web-SwaggerUI/Alpine/run.sh
+++ b/Web-SwaggerUI/Alpine/run.sh
@@ -5,7 +5,7 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 set -e
-set -x
+set +x
 
 envsubst < /app/appsettings.template.json > /app/appsettings.json
 

--- a/generate-cert.sh
+++ b/generate-cert.sh
@@ -6,7 +6,7 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 set -e
-set -x
+set +x
 
 mkdir -p ssl
 openssl dhparam -out ssl/dhparam.pem 4096


### PR DESCRIPTION
Using `set -x` instructs the shell to explain itself while running through scripts.  This is helpful while debugging but in production can cause the values of variables to be written to logs.  

For example, when the line `PGPASSWORD=$POSTGRES_PASSWORD` is executed, the shell writes  `+ PGPASSWORD=TheActualPostgresP@ssw0rd` to the screen.  In many cloud environments, the contents of stdout and stderr are captured and logged.  In these cases, using `set -x` causes the password to be written to logs.  

To prevent this, use `set +x` instead to require that the shell not explain itself while processing these scripts.  