### PR TITLE
[AA-1562] Elevate database script file permission

### DIFF
--- a/DB-Admin/Alpine/pgsql/Dockerfile
+++ b/DB-Admin/Alpine/pgsql/Dockerfile
@@ -29,7 +29,8 @@ RUN apk --no-cache add dos2unix=~7.4 unzip=~6.0 && \
     dos2unix /docker-entrypoint-initdb.d/2-run-adminapp-migrations.sh && \
     dos2unix /tmp/EdFi_Admin.sql && \
     dos2unix /tmp/EdFi_Security.sql && \
-    dos2unix /tmp/AdminAppScripts/PgSql/*
+    dos2unix /tmp/AdminAppScripts/PgSql/* && \
+    chmod -R 777 /tmp/AdminAppScripts/PgSql
 
 EXPOSE 5432
 


### PR DESCRIPTION
@andonyns 
Please help review and merge the changes.
Description:
Cause:
Since we moved our Admin App web and Admin App database packages pack and publish steps to Git hub actions. The build actions happening on UNIX environment, so the file level permissions are not retained on the recently created packages. This causes file read, write and some cases execute actions to fail.
In this specific case psql command can not read database script files to create database tables.
Fix:
We are fixing the issue by elevating the file permission using chmod on docker file. 