### PR TITLE
[AA-1580] Add Missing Setting to Fix Admin App E2E Tests

### DIFF
--- a/Web-Ods-AdminApp/Alpine/mssql/appsettings.template.json
+++ b/Web-Ods-AdminApp/Alpine/mssql/appsettings.template.json
@@ -22,6 +22,7 @@
     "PathBase": "$ADMINAPP_VIRTUAL_NAME",
     "GoogleAnalyticsMeasurementId": "",
     "EncryptionKey": "$ENCRYPTION_KEY",
+    "EnableProductImprovementSettings": true,
     "ProductRegistrationUrl": "https://edfi-tools-analytics.azurewebsites.net/data/v1/"
   },
   "ConnectionStrings": {

--- a/Web-Ods-AdminApp/Alpine/pgsql/appsettings.template.json
+++ b/Web-Ods-AdminApp/Alpine/pgsql/appsettings.template.json
@@ -22,6 +22,7 @@
     "PathBase": "$ADMINAPP_VIRTUAL_NAME",
     "GoogleAnalyticsMeasurementId": "",
     "EncryptionKey": "$ENCRYPTION_KEY",
+    "EnableProductImprovementSettings": true,
     "ProductRegistrationUrl": "https://edfi-tools-analytics.azurewebsites.net/data/v1/"
   },
   "ConnectionStrings": {


### PR DESCRIPTION
Introduces missing setting to Admin App's `appsettings.template.json`s which is `true` by default in repository appsettings. Currently defaulting to `false` by missing and causing Admin App automated E2E tests to fail.

Validation:

- see [passing run](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-AdminApp/actions/runs/3039088871/jobs/4893609131) of E2E tests (in "Run tests" step) from commit which changes this value [at the docker env level](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-AdminApp/compare/main...AA-1580-fix-failing-e2e-test)