### PR TITLE
ODS-5087 - Add healthcheck for Api, Sandbox, Swagger, and PgSQL database containers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,26 +56,26 @@ PGBOUNCER_QUIET="true"
 
 # The following needs to be set to specify a healthcheck test for admin app.
 # RECOMMENDED: To use the default internal Admin App healthcheck endpoint, set the variable as follows:
-ADMINAPP_HEALTHCHECK_TEST="curl -f http://${ADMINAPP_VIRTUAL_NAME}/health"
+ADMINAPP_HEALTHCHECK_TEST="curl -f http://localhost/health"
 #  To disable the healthcheck, remove the above and instead set the variable as follows:
 # ADMINAPP_HEALTHCHECK_TEST=/bin/true
 #  To add a custom health check, consult the documentation at https://docs.docker.com/compose/compose-file/compose-file-v3/#healthcheck
 
 # The following needs to be set to specify a healthcheck test for the API
 # RECOMMENDED: To use the default internal API healthcheck endpoint, set the variable as follows:
-API_HEALTHCHECK_TEST="curl -f http://${ODS_VIRTUAL_NAME}/health"
+API_HEALTHCHECK_TEST="curl -f http://localhost/health"
 #  To disable the healthcheck, remove the above and instead set the variable as follows:
 # API_HEALTHCHECK_TEST=/bin/true
 
 # The following needs to be set to specify a healthcheck test for the Sandbox Admin
 # RECOMMENDED: To use the default internal Sandbox Admin healthcheck endpoint, set the variable as follows:
-SANDBOX_HEALTHCHECK_TEST="curl -f http://${SANDBOX_ADMIN_VIRTUAL_NAME}/health"
+SANDBOX_HEALTHCHECK_TEST="curl -f http://localhost/health"
 #  To disable the healthcheck, remove the above and instead set the variable as follows:
 # SANDBOX_HEALTHCHECK_TEST=/bin/true
 
 # The following needs to be set to specify a healthcheck test for Swagger
 # RECOMMENDED: To use the default internal Swagger healthcheck endpoint, set the variable as follows:
-SWAGGER_HEALTHCHECK_TEST="curl -f http://${DOCS_VIRTUAL_NAME}/health"
+SWAGGER_HEALTHCHECK_TEST="curl -f http://localhost/health"
 #  To disable the healthcheck, remove the above and instead set the variable as follows:
 # SWAGGER_HEALTHCHECK_TEST=/bin/true
 

--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,12 @@ ADMINAPP_HEALTHCHECK_TEST="curl -f http://${ADMINAPP_VIRTUAL_NAME}/health"
 # ADMINAPP_HEALTHCHECK_TEST=/bin/true
 #  To add a custom health check, consult the documentation at https://docs.docker.com/compose/compose-file/compose-file-v3/#healthcheck
 
+# The following needs to be set to specify a healthcheck test for the API
+# RECOMMENDED: To use the default internal API healthcheck endpoint, set the variable as follows:
+API_HEALTHCHECK_TEST="curl -f http://${ODS_VIRTUAL_NAME}/health"
+#  To disable the healthcheck, remove the above and instead set the variable as follows:
+# API_HEALTHCHECK_TEST=/bin/true
+
 # The following needs to be set to specify the ODS API endpoint for admin app to internally connect to the API.
 # If you choose direct connection within the docker network between the ODS API and the admin app, then set the api internal url as follows:
 API_INTERNAL_URL=http://${ODS_VIRTUAL_NAME}

--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,12 @@ SANDBOX_HEALTHCHECK_TEST="curl -f http://${SANDBOX_ADMIN_VIRTUAL_NAME}/health"
 #  To disable the healthcheck, remove the above and instead set the variable as follows:
 # SANDBOX_HEALTHCHECK_TEST=/bin/true
 
+# The following needs to be set to specify a healthcheck test for Swagger
+# RECOMMENDED: To use the default internal Swagger healthcheck endpoint, set the variable as follows:
+SWAGGER_HEALTHCHECK_TEST="curl -f http://${DOCS_VIRTUAL_NAME}/health"
+#  To disable the healthcheck, remove the above and instead set the variable as follows:
+# SWAGGER_HEALTHCHECK_TEST=/bin/true
+
 # The following needs to be set to specify the ODS API endpoint for admin app to internally connect to the API.
 # If you choose direct connection within the docker network between the ODS API and the admin app, then set the api internal url as follows:
 API_INTERNAL_URL=http://${ODS_VIRTUAL_NAME}

--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,9 @@ PGBOUNCER_QUIET="true"
 # The url path to the admin app, the default is 'adminapp', only used by admin app.
 # ADMINAPP_VIRTUAL_NAME=<virtual name for the admin app endpoint>
 
+# The url path to swagger, the default is 'docs'
+# DOCS_VIRTUAL_NAME=<virtual name for the swagger endpoint>
+
 # The following needs to be set to specify a healthcheck test for admin app.
 # RECOMMENDED: To use the default internal Admin App healthcheck endpoint, set the variable as follows:
 ADMINAPP_HEALTHCHECK_TEST="curl -f http://${ADMINAPP_VIRTUAL_NAME}/health"

--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,7 @@ POSTGRES_PASSWORD=<password for default postgres user>
 # Port PgBouncer listens on, only needed if using Postgres DB, defaults to 6432
 # PGBOUNCER_LISTEN_PORT=<port for pg bouncer to listen to>
 
-# NOTE - By default, PgBouncer logs the configuration file which contains sensitive information such as the host database username and password.  
+# NOTE - By default, PgBouncer logs the configuration file which contains sensitive information such as the host database username and password.
 # The following configuration variable PGBOUNCER_QUIET="true" which will suppress this messaging.
 PGBOUNCER_QUIET="true"
 
@@ -63,6 +63,12 @@ ADMINAPP_HEALTHCHECK_TEST="curl -f http://${ADMINAPP_VIRTUAL_NAME}/health"
 API_HEALTHCHECK_TEST="curl -f http://${ODS_VIRTUAL_NAME}/health"
 #  To disable the healthcheck, remove the above and instead set the variable as follows:
 # API_HEALTHCHECK_TEST=/bin/true
+
+# The following needs to be set to specify a healthcheck test for the Sandbox Admin
+# RECOMMENDED: To use the default internal Sandbox Admin healthcheck endpoint, set the variable as follows:
+SANDBOX_HEALTHCHECK_TEST="curl -f http://${SANDBOX_ADMIN_VIRTUAL_NAME}/health"
+#  To disable the healthcheck, remove the above and instead set the variable as follows:
+# SANDBOX_HEALTHCHECK_TEST=/bin/true
 
 # The following needs to be set to specify the ODS API endpoint for admin app to internally connect to the API.
 # If you choose direct connection within the docker network between the ODS API and the admin app, then set the api internal url as follows:

--- a/Compose-Generator/Alpine/templates/pgsql/template.mustache
+++ b/Compose-Generator/Alpine/templates/pgsql/template.mustache
@@ -67,6 +67,7 @@ services:
       ApiSettings__PathBase: "${ODS_VIRTUAL_NAME:-api}"
       TPDM_ENABLED: "${TPDM_ENABLED:-true}"
       ODS_WAIT_POSTGRES_HOSTS: "{{#tokens}}EdFi_Ods_{{token}} {{/tokens}}"
+      API_HEALTHCHECK_TEST: ${API_HEALTHCHECK_TEST?Please consult env.example to set the API healthcheck test}
     volumes:
       - ${LOGS_FOLDER}:/app/logs
     depends_on:
@@ -77,6 +78,10 @@ services:
     restart: always
     hostname: api
     container_name: ed-fi-ods-api
+    healthcheck:
+      test: $$API_HEALTHCHECK_TEST
+      start_period: "60s"
+      retries: 3
 
   {{#tokens}}
 

--- a/Compose/mssql/compose-sandbox-env-build.yml
+++ b/Compose/mssql/compose-sandbox-env-build.yml
@@ -78,9 +78,14 @@ services:
       POPULATED_SECRET: "${POPULATED_SECRET}"
       WebApiVersionUrl: "https://localhost/${ODS_VIRTUAL_NAME:-api}/"
       PathBase: "${DOCS_VIRTUAL_NAME:-docs}"
+      SWAGGER_HEALTHCHECK_TEST: ${SWAGGER_HEALTHCHECK_TEST?Please consult env.example to set the SWAGGER healthcheck test}
     depends_on:
       - api
       - admin
     restart: always
     hostname: swagger
     container_name: ed-fi-swagger
+    healthcheck:
+      test: $$SWAGGER_HEALTHCHECK_TEST
+      start_period: "60s"
+      retries: 3

--- a/Compose/mssql/compose-sandbox-env.yml
+++ b/Compose/mssql/compose-sandbox-env.yml
@@ -70,9 +70,14 @@ services:
       POPULATED_SECRET: "${POPULATED_SECRET}"
       WebApiVersionUrl: "https://localhost/${ODS_VIRTUAL_NAME:-api}/"
       PathBase: "${DOCS_VIRTUAL_NAME:-docs}"
+      SWAGGER_HEALTHCHECK_TEST: ${SWAGGER_HEALTHCHECK_TEST?Please consult env.example to set the SWAGGER healthcheck test}
     depends_on:
       - api
       - admin
     restart: always
     hostname: swagger
     container_name: ed-fi-swagger
+    healthcheck:
+      test: $$SWAGGER_HEALTHCHECK_TEST
+      start_period: "60s"
+      retries: 3

--- a/Compose/pgsql/compose-district-specific-env-build.example.yml
+++ b/Compose/pgsql/compose-district-specific-env-build.example.yml
@@ -52,6 +52,7 @@ services:
       ApiSettings__PathBase: "${ODS_VIRTUAL_NAME:-api}"
       TPDM_ENABLED: "${TPDM_ENABLED:-true}"
       ODS_WAIT_POSTGRES_HOSTS: "EdFi_Ods_255901 EdFi_Ods_255902 "
+      API_HEALTHCHECK_TEST: ${API_HEALTHCHECK_TEST?Please consult env.example to set the API healthcheck test}
     volumes:
       - ${LOGS_FOLDER}:/app/logs
     depends_on:
@@ -61,6 +62,10 @@ services:
     restart: always
     hostname: api
     container_name: ed-fi-ods-api
+    healthcheck:
+      test: $$API_HEALTHCHECK_TEST
+      start_period: "60s"
+      retries: 3
 
 
   db-ods-255901:

--- a/Compose/pgsql/compose-district-specific-env.example.yml
+++ b/Compose/pgsql/compose-district-specific-env.example.yml
@@ -46,6 +46,7 @@ services:
       ApiSettings__PathBase: "${ODS_VIRTUAL_NAME:-api}"
       TPDM_ENABLED: "${TPDM_ENABLED:-true}"
       ODS_WAIT_POSTGRES_HOSTS: "EdFi_Ods_255901 EdFi_Ods_255902 "
+      API_HEALTHCHECK_TEST: ${API_HEALTHCHECK_TEST?Please consult env.example to set the API healthcheck test}
     volumes:
       - ${LOGS_FOLDER}:/app/logs
     depends_on:
@@ -55,6 +56,10 @@ services:
     restart: always
     hostname: api
     container_name: ed-fi-ods-api
+    healthcheck:
+      test: $$API_HEALTHCHECK_TEST
+      start_period: "60s"
+      retries: 3
 
 
   db-ods-255901:

--- a/Compose/pgsql/compose-sandbox-env-build.yml
+++ b/Compose/pgsql/compose-sandbox-env-build.yml
@@ -18,6 +18,10 @@ services:
       - vol-db-ods:/var/lib/postgresql/data
     restart: always
     container_name: ed-fi-db-ods
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      start_period: "60s"
+      retries: 3
 
   db-admin:
     build:
@@ -31,6 +35,10 @@ services:
       - vol-db-admin:/var/lib/postgresql/data
     restart: always
     container_name: ed-fi-db-admin
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      start_period: "60s"
+      retries: 3
 
   nginx:
     build:

--- a/Compose/pgsql/compose-sandbox-env-build.yml
+++ b/Compose/pgsql/compose-sandbox-env-build.yml
@@ -141,7 +141,7 @@ services:
     healthcheck:
       test: $$SWAGGER_HEALTHCHECK_TEST
       start_period: "60s"
-      retries: 5
+      retries: 3
 
   pb-admin:
     image: pgbouncer/pgbouncer

--- a/Compose/pgsql/compose-sandbox-env-build.yml
+++ b/Compose/pgsql/compose-sandbox-env-build.yml
@@ -65,6 +65,7 @@ services:
       ADMIN_POSTGRES_HOST: pb-admin
       ApiSettings__PathBase: "${ODS_VIRTUAL_NAME:-api}"
       TPDM_ENABLED: "${TPDM_ENABLED:-true}"
+      API_HEALTHCHECK_TEST: ${API_HEALTHCHECK_TEST?Please consult env.example to set the API healthcheck test}
     volumes:
       - ${LOGS_FOLDER}:/app/logs
     depends_on:
@@ -74,6 +75,10 @@ services:
     restart: always
     hostname: api
     container_name: ed-fi-ods-api
+    healthcheck:
+      test: $$API_HEALTHCHECK_TEST
+      start_period: "60s"
+      retries: 3
 
   admin:
     build:

--- a/Compose/pgsql/compose-sandbox-env-build.yml
+++ b/Compose/pgsql/compose-sandbox-env-build.yml
@@ -121,6 +121,7 @@ services:
       POPULATED_SECRET: "${POPULATED_SECRET}"
       WebApiVersionUrl: "https://localhost/${ODS_VIRTUAL_NAME:-api}/"
       PathBase: "${DOCS_VIRTUAL_NAME:-docs}"
+      SWAGGER_HEALTHCHECK_TEST: ${SWAGGER_HEALTHCHECK_TEST?Please consult env.example to set the SWAGGER healthcheck test}
     depends_on:
       - api
       - admin
@@ -129,6 +130,10 @@ services:
     restart: always
     hostname: swagger
     container_name: ed-fi-swagger
+    healthcheck:
+      test: $$SWAGGER_HEALTHCHECK_TEST
+      start_period: "60s"
+      retries: 5
 
   pb-admin:
     image: pgbouncer/pgbouncer

--- a/Compose/pgsql/compose-sandbox-env-build.yml
+++ b/Compose/pgsql/compose-sandbox-env-build.yml
@@ -98,6 +98,7 @@ services:
       ADMIN_POSTGRES_HOST: pb-admin
       PathBase: "${SANDBOX_ADMIN_VIRTUAL_NAME:-admin}"
       OAuthUrl: "https://localhost/${ODS_VIRTUAL_NAME:-api}/oauth/"
+      SANDBOX_HEALTHCHECK_TEST: ${SANDBOX_HEALTHCHECK_TEST?Please consult env.example to set the API healthcheck test}
     volumes:
       - ${LOGS_FOLDER}:/app/logs
     depends_on:
@@ -106,6 +107,10 @@ services:
     restart: always
     hostname: admin
     container_name: ed-fi-sandbox-admin
+    healthcheck:
+      test: $$SANDBOX_HEALTHCHECK_TEST
+      start_period: "60s"
+      retries: 3
 
   swagger:
     build:

--- a/Compose/pgsql/compose-sandbox-env.yml
+++ b/Compose/pgsql/compose-sandbox-env.yml
@@ -109,6 +109,7 @@ services:
       POPULATED_SECRET: "${POPULATED_SECRET}"
       WebApiVersionUrl: "https://localhost/${ODS_VIRTUAL_NAME:-api}/"
       PathBase: "${DOCS_VIRTUAL_NAME:-docs}"
+      SWAGGER_HEALTHCHECK_TEST: ${SWAGGER_HEALTHCHECK_TEST?Please consult env.example to set the SWAGGER healthcheck test}
     depends_on:
       - api
       - admin
@@ -117,6 +118,10 @@ services:
     restart: always
     hostname: swagger
     container_name: ed-fi-swagger
+    healthcheck:
+      test: $$SWAGGER_HEALTHCHECK_TEST
+      start_period: "60s"
+      retries: 3
 
   pb-admin:
     image: pgbouncer/pgbouncer

--- a/Compose/pgsql/compose-sandbox-env.yml
+++ b/Compose/pgsql/compose-sandbox-env.yml
@@ -88,6 +88,7 @@ services:
       ADMIN_POSTGRES_HOST: pb-admin
       PathBase: "${SANDBOX_ADMIN_VIRTUAL_NAME:-admin}"
       OAuthUrl: "https://localhost/${ODS_VIRTUAL_NAME:-api}/oauth/"
+      SANDBOX_HEALTHCHECK_TEST: ${SANDBOX_HEALTHCHECK_TEST?Please consult env.example to set the API healthcheck test}
     volumes:
       - ${LOGS_FOLDER}:/app/logs
     depends_on:
@@ -96,6 +97,10 @@ services:
     restart: always
     hostname: admin
     container_name: ed-fi-sandbox-admin
+    healthcheck:
+      test: $$SANDBOX_HEALTHCHECK_TEST
+      start_period: "60s"
+      retries: 3
 
   swagger:
     image: edfialliance/ods-api-web-swaggerui:${TAG}

--- a/Compose/pgsql/compose-sandbox-env.yml
+++ b/Compose/pgsql/compose-sandbox-env.yml
@@ -16,6 +16,10 @@ services:
       - vol-db-ods:/var/lib/postgresql/data
     restart: always
     container_name: ed-fi-db-ods
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      start_period: "60s"
+      retries: 3
 
   db-admin:
     image: edfialliance/ods-api-db-admin:${TAG}
@@ -27,6 +31,10 @@ services:
       - vol-db-admin:/var/lib/postgresql/data
     restart: always
     container_name: ed-fi-db-admin
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      start_period: "60s"
+      retries: 3
 
   nginx:
     image: edfialliance/ods-api-web-gateway-sandbox:${TAG}

--- a/Compose/pgsql/compose-sandbox-env.yml
+++ b/Compose/pgsql/compose-sandbox-env.yml
@@ -57,6 +57,7 @@ services:
       ADMIN_POSTGRES_HOST: pb-admin
       ApiSettings__PathBase: "${ODS_VIRTUAL_NAME:-api}"
       TPDM_ENABLED: "${TPDM_ENABLED:-true}"
+      API_HEALTHCHECK_TEST: ${API_HEALTHCHECK_TEST?Please consult env.example to set the API healthcheck test}
     volumes:
       - ${LOGS_FOLDER}:/app/logs
     depends_on:
@@ -66,6 +67,10 @@ services:
     restart: always
     hostname: api
     container_name: ed-fi-ods-api
+    healthcheck:
+      test: $$API_HEALTHCHECK_TEST
+      start_period: "60s"
+      retries: 3
 
   admin:
     image: edfialliance/ods-api-web-sandbox-admin:${TAG}

--- a/Compose/pgsql/compose-shared-instance-env-build.yml
+++ b/Compose/pgsql/compose-shared-instance-env-build.yml
@@ -64,6 +64,7 @@ services:
       API_MODE: "SharedInstance"
       ApiSettings__PathBase: "${ODS_VIRTUAL_NAME:-api}"
       TPDM_ENABLED: "${TPDM_ENABLED:-true}"
+      API_HEALTHCHECK_TEST: ${API_HEALTHCHECK_TEST?Please consult env.example to set the API healthcheck test}
     volumes:
       - ${LOGS_FOLDER}:/app/logs
     depends_on:
@@ -72,6 +73,10 @@ services:
     restart: always
     hostname: api
     container_name: ed-fi-ods-api
+    healthcheck:
+      test: $$API_HEALTHCHECK_TEST
+      start_period: "60s"
+      retries: 3
 
   adminapp:
     build:

--- a/Compose/pgsql/compose-shared-instance-env.yml
+++ b/Compose/pgsql/compose-shared-instance-env.yml
@@ -56,6 +56,7 @@ services:
       API_MODE: "SharedInstance"
       ApiSettings__PathBase: "${ODS_VIRTUAL_NAME:-api}"
       TPDM_ENABLED: "${TPDM_ENABLED:-true}"
+      API_HEALTHCHECK_TEST: ${API_HEALTHCHECK_TEST?Please consult env.example to set the API healthcheck test}
     volumes:
       - ${LOGS_FOLDER}:/app/logs
     depends_on:
@@ -64,6 +65,10 @@ services:
     restart: always
     hostname: api
     container_name: ed-fi-ods-api
+    healthcheck:
+      test: $$API_HEALTHCHECK_TEST
+      start_period: "60s"
+      retries: 3
 
   adminapp:
     image: edfialliance/ods-admin-app:${TAG}

--- a/Compose/pgsql/compose-year-specific-env-build.example.yml
+++ b/Compose/pgsql/compose-year-specific-env-build.example.yml
@@ -52,6 +52,7 @@ services:
       ApiSettings__PathBase: "${ODS_VIRTUAL_NAME:-api}"
       TPDM_ENABLED: "${TPDM_ENABLED:-true}"
       ODS_WAIT_POSTGRES_HOSTS: "EdFi_Ods_2021 EdFi_Ods_2022 "
+      API_HEALTHCHECK_TEST: ${API_HEALTHCHECK_TEST?Please consult env.example to set the API healthcheck test}
     volumes:
       - ${LOGS_FOLDER}:/app/logs
     depends_on:
@@ -61,6 +62,10 @@ services:
     restart: always
     hostname: api
     container_name: ed-fi-ods-api
+    healthcheck:
+      test: $$API_HEALTHCHECK_TEST
+      start_period: "60s"
+      retries: 3
 
 
   db-ods-2021:

--- a/Compose/pgsql/compose-year-specific-env.example.yml
+++ b/Compose/pgsql/compose-year-specific-env.example.yml
@@ -46,6 +46,7 @@ services:
       ApiSettings__PathBase: "${ODS_VIRTUAL_NAME:-api}"
       TPDM_ENABLED: "${TPDM_ENABLED:-true}"
       ODS_WAIT_POSTGRES_HOSTS: "EdFi_Ods_2021 EdFi_Ods_2022 "
+      API_HEALTHCHECK_TEST: ${API_HEALTHCHECK_TEST?Please consult env.example to set the API healthcheck test}
     volumes:
       - ${LOGS_FOLDER}:/app/logs
     depends_on:
@@ -55,6 +56,10 @@ services:
     restart: always
     hostname: api
     container_name: ed-fi-ods-api
+    healthcheck:
+      test: $$API_HEALTHCHECK_TEST
+      start_period: "60s"
+      retries: 3
 
 
   db-ods-2021:

--- a/Web-Ods-Api/Alpine/mssql/Dockerfile
+++ b/Web-Ods-Api/Alpine/mssql/Dockerfile
@@ -18,7 +18,7 @@ COPY appsettings.template.json /app/appsettings.template.json
 COPY run.sh /app/run.sh
 COPY log4net.config /app/log4net.txt
 
-RUN apk --no-cache add unzip=~6.0 dos2unix=~7.4 bash=~5.1 gettext=~0.21 icu=~71.1-r2 && \
+RUN apk --no-cache add unzip=~6.0 dos2unix=~7.4 bash=~5.1 gettext=~0.21 icu=~71.1-r2 curl=~7.83.1-r3 && \
     wget -O /app/WebApi.zip  https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.Suite3.Ods.WebApi/versions/${VERSION}/content && \
     unzip /app/WebApi.zip -d /app && \
     rm -f /app/WebApi.zip && \

--- a/Web-Ods-Api/Alpine/pgsql/Dockerfile
+++ b/Web-Ods-Api/Alpine/pgsql/Dockerfile
@@ -22,7 +22,7 @@ COPY appsettings.template.json /app/appsettings.template.json
 COPY run.sh /app/run.sh
 COPY log4net.config /app/log4net.txt
 
-RUN apk --no-cache add unzip=~6.0 dos2unix=~7.4 bash=~5.1 gettext=~0.21 postgresql13-client=~13.8-r0 icu=~71.1-r2 && \
+RUN apk --no-cache add unzip=~6.0 dos2unix=~7.4 bash=~5.1 gettext=~0.21 postgresql13-client=~13.8-r0 icu=~71.1-r2 curl=~7.83.1-r3 && \
     wget -O /app/WebApi.zip https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.Suite3.Ods.WebApi/versions/${VERSION}/content && \
     unzip /app/WebApi.zip -d /app && \
     rm -f /app/WebApi.zip && \

--- a/Web-Sandbox-Admin/Alpine/mssql/Dockerfile
+++ b/Web-Sandbox-Admin/Alpine/mssql/Dockerfile
@@ -23,7 +23,7 @@ COPY appsettings.template.json /app/appsettings.template.json
 COPY run.sh /app/run.sh
 COPY log4net.config /app/log4net.txt
 
-RUN apk --no-cache add unzip=~6.0 dos2unix=~7.4 bash=~5.1 gettext=~0.21 icu=~71.1-r2 && \
+RUN apk --no-cache add unzip=~6.0 dos2unix=~7.4 bash=~5.1 gettext=~0.21 icu=~71.1-r2 curl=~7.83.1-r3 && \
     wget -O /app/SandboxAdmin.zip https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.Suite3.Ods.SandboxAdmin/versions/${VERSION}/content && \
     unzip /app/SandboxAdmin.zip -d /app && \
     rm -f /app/SandboxAdmin.zip && \

--- a/Web-Sandbox-Admin/Alpine/pgsql/Dockerfile
+++ b/Web-Sandbox-Admin/Alpine/pgsql/Dockerfile
@@ -23,7 +23,7 @@ COPY appsettings.template.json /app/appsettings.template.json
 COPY run.sh /app/run.sh
 COPY log4net.config /app/log4net.txt
 
-RUN apk --no-cache add unzip=~6.0 dos2unix=~7.4 bash=~5.1 gettext=~0.21 postgresql13-client=~13.8-r0 icu=~71.1-r2 && \
+RUN apk --no-cache add unzip=~6.0 dos2unix=~7.4 bash=~5.1 gettext=~0.21 postgresql13-client=~13.8-r0 icu=~71.1-r2 curl=~7.83.1-r3 && \
     wget -O /app/SandboxAdmin.zip https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.Suite3.Ods.SandboxAdmin/versions/${VERSION}/content && \
     unzip /app/SandboxAdmin.zip -d /app && \
     rm -f /app/SandboxAdmin.zip && \

--- a/Web-SwaggerUI/Alpine/Dockerfile
+++ b/Web-SwaggerUI/Alpine/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /app
 COPY appsettings.template.json /app/appsettings.template.json
 COPY run.sh /app/run.sh
 
-RUN apk --no-cache add unzip=~6.0 dos2unix=~7.4 bash=~5.1 gettext=~0.21 icu=~71.1-r2 && \
+RUN apk --no-cache add unzip=~6.0 dos2unix=~7.4 bash=~5.1 gettext=~0.21 icu=~71.1-r2 curl=~7.83.1-r3 && \
     wget -O /app/SwaggerUI.zip https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.Suite3.Ods.SwaggerUI/versions/${VERSION}/content && \
     unzip /app/SwaggerUI.zip -d /app && \
     rm -f /app/SwaggerUI.zip && \


### PR DESCRIPTION
Following the format established by Admin App in AA-1358, health checks were added for the remaining application containers.

For the database containers, a health check was added following the advice [here](https://github.com/peter-evans/docker-compose-healthcheck) where we utilize the `pg_isready` function to determine if the database is healthy

With these changes for the application health checks, we updated it to have hard coded env values of http://localhost/health instead of using the virtual name. Below I am copying and pasting the comment from @AxelMarquez on the tracker ticket on the reasoning behind this:

> Health checks are shell commands executed within the container that they are defined, meaning that they use the docker-compose internal network.
> Virtual name env vars (for example ADMINAPP_VIRTUAL_NAME, ODS_VIRTUAL_NAME, ...) tell Nginx what paths it has to proxy.
> 
> However, [AdminApp health check definition uses ADMINAPP_VIRTUAL_NAME](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Docker/blob/528e3a24db25faed04195f03b905e7c64d00f99d/.env.example#L56), which will cause the health check to fail if its value isn't either the [container hostname](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Docker/blob/2cae7958e6ddd4b1eaf33de30fc505e7986701ca/Compose/pgsql/compose-shared-instance-env.yml#L91) or "localhost". 
> For example, let's imagine that ADMINAPP_VIRTUAL_NAME = "test", AdminApp will be available from the host machine at "localhost/test" (served by Nginx). 
> But within docker-compose internal network, it is still available at "adminapp" since that is the container hostname; it will not be available at "test" unless the request is explicitly routed through the Ngninx container like "nginx/test".
> 
> Consider the next image. I set ADMINAPP_VIRTUAL_NAME = "axel", so it is available from the host machine at "localhost/axel", however, the health check fails since there is no container with hostname "axel":

![image](https://user-images.githubusercontent.com/1013553/190486328-30a9e8f7-730b-4001-af7c-2fd34253ee4a.png)

