### PR TITLE
[AA-1567] Update Packages for Admin App 2.4

### DIFF
--- a/DB-Admin/Alpine/pgsql/Dockerfile
+++ b/DB-Admin/Alpine/pgsql/Dockerfile
@@ -13,7 +13,7 @@ ENV POSTGRES_DB=postgres
 
 ENV ADMIN_VERSION="6.0.110"
 ENV SECURITY_VERSION="6.0.126"
-ENV ADMINAPP_DATABASE_VERSION="2.4.37"
+ENV ADMINAPP_DATABASE_VERSION="2.4.48"
 
 COPY init-database.sh /docker-entrypoint-initdb.d/1-init-database.sh
 COPY run-adminapp-migrations.sh /docker-entrypoint-initdb.d/2-run-adminapp-migrations.sh

--- a/Web-Ods-AdminApp/Alpine/mssql/Dockerfile
+++ b/Web-Ods-AdminApp/Alpine/mssql/Dockerfile
@@ -7,7 +7,7 @@
 FROM mcr.microsoft.com/dotnet/aspnet@sha256:4e32cb869308e781e518f721b25bd26b3a91fb3e2100c6d29e72176f75417472
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
 
-ENV VERSION="2.4.37"
+ENV VERSION="2.4.48"
 ENV PGBOUNCER_LISTEN_PORT=6432
 ENV ADMINAPP_VIRTUAL_NAME=adminapp
 ENV API_MODE=SharedInstance

--- a/Web-Ods-AdminApp/Alpine/pgsql/Dockerfile
+++ b/Web-Ods-AdminApp/Alpine/pgsql/Dockerfile
@@ -7,7 +7,7 @@
 FROM mcr.microsoft.com/dotnet/aspnet@sha256:4e32cb869308e781e518f721b25bd26b3a91fb3e2100c6d29e72176f75417472
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
 
-ENV VERSION="2.4.37"
+ENV VERSION="2.4.48"
 ENV POSTGRES_PORT=5432
 ENV PGBOUNCER_LISTEN_PORT=6432
 ENV ADMINAPP_VIRTUAL_NAME=adminapp


### PR DESCRIPTION
Update package versions for Admin App Web & DB images to the release build of v2.4: `2.4.48`.
This version provides bug fixes and new features with support for ODS/API versions v3.4 through v5.3.