### PR TITLE
[AA-1567] Release Tag for Admin App 2.4

### DIFF
--- a/DB-Admin/Alpine/pgsql/Dockerfile
+++ b/DB-Admin/Alpine/pgsql/Dockerfile
@@ -4,7 +4,7 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 # Tag postgres:11-alpine
-FROM postgres@sha256:386802b61d7226cdcf8710ed6e5e46f993e0da1f3dd2e829cbab12ee91b888ad
+FROM postgres@sha256:fc3670fa23119159394dfdb98eee89b30ef5a506791aea6ff7d8a4e73a8cd4a4
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
 
 ENV POSTGRES_USER=${POSTGRES_USER}

--- a/DB-Admin/Alpine/pgsql/Dockerfile
+++ b/DB-Admin/Alpine/pgsql/Dockerfile
@@ -29,7 +29,8 @@ RUN apk --no-cache add dos2unix=~7.4 unzip=~6.0 && \
     dos2unix /docker-entrypoint-initdb.d/2-run-adminapp-migrations.sh && \
     dos2unix /tmp/EdFi_Admin.sql && \
     dos2unix /tmp/EdFi_Security.sql && \
-    dos2unix /tmp/AdminAppScripts/PgSql/*
+    dos2unix /tmp/AdminAppScripts/PgSql/* && \
+    chmod -R 777 /tmp/AdminAppScripts/PgSql
 
 EXPOSE 5432
 

--- a/DB-Admin/Alpine/pgsql/Dockerfile
+++ b/DB-Admin/Alpine/pgsql/Dockerfile
@@ -4,7 +4,7 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 # Tag postgres:11-alpine
-FROM postgres@sha256:386802b61d7226cdcf8710ed6e5e46f993e0da1f3dd2e829cbab12ee91b888ad 
+FROM postgres@sha256:386802b61d7226cdcf8710ed6e5e46f993e0da1f3dd2e829cbab12ee91b888ad
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
 
 ENV POSTGRES_USER=${POSTGRES_USER}
@@ -13,7 +13,7 @@ ENV POSTGRES_DB=postgres
 
 ENV ADMIN_VERSION="5.3.154"
 ENV SECURITY_VERSION="5.3.152"
-ENV ADMINAPP_DATABASE_VERSION="2.3.2"
+ENV ADMINAPP_DATABASE_VERSION="2.4.48"
 
 COPY init-database.sh /docker-entrypoint-initdb.d/1-init-database.sh
 COPY run-adminapp-migrations.sh /docker-entrypoint-initdb.d/2-run-adminapp-migrations.sh

--- a/DB-Admin/Alpine/pgsql/Dockerfile
+++ b/DB-Admin/Alpine/pgsql/Dockerfile
@@ -4,7 +4,7 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 # Tag postgres:11-alpine
-FROM postgres@sha256:fc3670fa23119159394dfdb98eee89b30ef5a506791aea6ff7d8a4e73a8cd4a4
+FROM postgres@sha256:386802b61d7226cdcf8710ed6e5e46f993e0da1f3dd2e829cbab12ee91b888ad
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
 
 ENV POSTGRES_USER=${POSTGRES_USER}

--- a/Web-Ods-AdminApp/Alpine/mssql/Dockerfile
+++ b/Web-Ods-AdminApp/Alpine/mssql/Dockerfile
@@ -21,7 +21,7 @@ COPY appsettings.template.json /app/appsettings.template.json
 COPY run.sh /app/run.sh
 COPY log4net.config /app/log4net.txt
 
-RUN apk --no-cache add unzip=~6.0 dos2unix=~7.4 bash=~5.1 gettext=~0.21 jq=~1.6 icu=~67.1 curl=~7.79 && \
+RUN apk --no-cache add unzip=~6.0 dos2unix=~7.4 bash=~5.1 gettext=~0.21 jq=~1.6 icu=~71.1-r2 curl=~7.83.1-r3 && \
     wget -O /app/AdminApp.zip https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.Suite3.ODS.AdminApp.Web/versions/${VERSION}/content && \
     unzip /app/AdminApp.zip -d /app && \
     rm -f /app/AdminApp.zip && \

--- a/Web-Ods-AdminApp/Alpine/mssql/Dockerfile
+++ b/Web-Ods-AdminApp/Alpine/mssql/Dockerfile
@@ -3,8 +3,8 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
-# Tag aspnet:3.1-alpine
-FROM mcr.microsoft.com/dotnet/core/aspnet@sha256:16332ec13dd77a8400edda0fb513b6ae204549adcd957aaa20dad6d26f645b5d
+# Tag aspnet:6.0-alpine
+FROM mcr.microsoft.com/dotnet/aspnet@sha256:4e32cb869308e781e518f721b25bd26b3a91fb3e2100c6d29e72176f75417472
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
 
 ENV VERSION="2.4.48"

--- a/Web-Ods-AdminApp/Alpine/mssql/Dockerfile
+++ b/Web-Ods-AdminApp/Alpine/mssql/Dockerfile
@@ -7,7 +7,7 @@
 FROM mcr.microsoft.com/dotnet/core/aspnet@sha256:16332ec13dd77a8400edda0fb513b6ae204549adcd957aaa20dad6d26f645b5d
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
 
-ENV VERSION="2.3.2"
+ENV VERSION="2.4.48"
 ENV PGBOUNCER_LISTEN_PORT=6432
 ENV ADMINAPP_VIRTUAL_NAME=adminapp
 ENV API_MODE=SharedInstance

--- a/Web-Ods-AdminApp/Alpine/mssql/appsettings.template.json
+++ b/Web-Ods-AdminApp/Alpine/mssql/appsettings.template.json
@@ -22,6 +22,7 @@
     "PathBase": "$ADMINAPP_VIRTUAL_NAME",
     "GoogleAnalyticsMeasurementId": "",
     "EncryptionKey": "$ENCRYPTION_KEY",
+    "EnableProductImprovementSettings": true,
     "ProductRegistrationUrl": "https://edfi-tools-analytics.azurewebsites.net/data/v1/"
   },
   "ConnectionStrings": {

--- a/Web-Ods-AdminApp/Alpine/pgsql/Dockerfile
+++ b/Web-Ods-AdminApp/Alpine/pgsql/Dockerfile
@@ -3,8 +3,8 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
-# Tag aspnet:3.1-alpine
-FROM mcr.microsoft.com/dotnet/core/aspnet@sha256:16332ec13dd77a8400edda0fb513b6ae204549adcd957aaa20dad6d26f645b5d
+# Tag aspnet:6.0-alpine
+FROM mcr.microsoft.com/dotnet/aspnet@sha256:4e32cb869308e781e518f721b25bd26b3a91fb3e2100c6d29e72176f75417472
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
 
 ENV VERSION="2.4.48"

--- a/Web-Ods-AdminApp/Alpine/pgsql/Dockerfile
+++ b/Web-Ods-AdminApp/Alpine/pgsql/Dockerfile
@@ -7,7 +7,7 @@
 FROM mcr.microsoft.com/dotnet/core/aspnet@sha256:16332ec13dd77a8400edda0fb513b6ae204549adcd957aaa20dad6d26f645b5d
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
 
-ENV VERSION="2.3.2"
+ENV VERSION="2.4.48"
 ENV POSTGRES_PORT=5432
 ENV PGBOUNCER_LISTEN_PORT=6432
 ENV ADMINAPP_VIRTUAL_NAME=adminapp

--- a/Web-Ods-AdminApp/Alpine/pgsql/Dockerfile
+++ b/Web-Ods-AdminApp/Alpine/pgsql/Dockerfile
@@ -22,7 +22,7 @@ COPY appsettings.template.json /app/appsettings.template.json
 COPY run.sh /app/run.sh
 COPY log4net.config /app/log4net.txt
 
-RUN apk --no-cache add unzip=~6.0 dos2unix=~7.4 bash=~5.1 gettext=~0.21 postgresql-client=~13.7-r0 jq=~1.6 icu=~67.1 curl=~7.79 && \
+RUN apk --no-cache add unzip=~6.0 dos2unix=~7.4 bash=~5.1 gettext=~0.21 postgresql13-client=~13.8-r0 jq=~1.6 icu=~71.1-r2 curl=~7.83.1-r3 && \
     wget -O /app/AdminApp.zip  https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.Suite3.ODS.AdminApp.Web/versions/${VERSION}/content && \
     unzip /app/AdminApp.zip -d /app && \
     rm -f /app/AdminApp.zip && \

--- a/Web-Ods-AdminApp/Alpine/pgsql/appsettings.template.json
+++ b/Web-Ods-AdminApp/Alpine/pgsql/appsettings.template.json
@@ -22,6 +22,7 @@
     "PathBase": "$ADMINAPP_VIRTUAL_NAME",
     "GoogleAnalyticsMeasurementId": "",
     "EncryptionKey": "$ENCRYPTION_KEY",
+    "EnableProductImprovementSettings": true,
     "ProductRegistrationUrl": "https://edfi-tools-analytics.azurewebsites.net/data/v1/"
   },
   "ConnectionStrings": {


### PR DESCRIPTION
Looking for a "👍" of approval before creating a release tag for a new image for Admin App 2.4 (tag `v2.1.3`) from this point.

- starting from v2.1.2 tag
- cherry-picked #121 for new Admin App setting
- new commits to update Admin App packages