### PR TITLE
[ODS-5584] Making SSL mount optional for AdminApp image

### DIFF
--- a/Web-Ods-AdminApp/Alpine/mssql/run.sh
+++ b/Web-Ods-AdminApp/Alpine/mssql/run.sh
@@ -31,7 +31,9 @@ mv /app/temp.json /app/appsettings.json
 # >&2 echo "Postgres is up - executing command"
 # exec $cmd
 
-cp /ssl/server.crt /usr/local/share/ca-certificates/
-update-ca-certificates
+if [ -f /ssl/server.crt ]; then
+  cp /ssl/server.crt /usr/local/share/ca-certificates/
+  update-ca-certificates
+fi
 
 dotnet EdFi.Ods.AdminApp.Web.dll

--- a/Web-Ods-AdminApp/Alpine/pgsql/run.sh
+++ b/Web-Ods-AdminApp/Alpine/pgsql/run.sh
@@ -40,8 +40,9 @@ done
 >&2 echo "Postgres is up - executing command"
 exec $cmd
 
-
-cp /ssl/server.crt /usr/local/share/ca-certificates/
-update-ca-certificates
+if [ -f /ssl/server.crt ]; then
+  cp /ssl/server.crt /usr/local/share/ca-certificates/
+  update-ca-certificates
+fi
 
 dotnet EdFi.Ods.AdminApp.Web.dll


### PR DESCRIPTION
**Context**

Right now Ed-Fi Docker images are hardwired to only run if they have an SSL certificate mounted in a docker volume. This makes it incompatible to run in a cloud environment where SSL encryption is usually handled by another service like a load balancer or an API Gateway. An example of this behavior can be seen in the link below.

https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Docker/blob/5ae5208f3dde940ae14e5fc93a79323419e77b21/Web-Ods-AdminApp/Alpine/pgsql/run.sh#L44

**Solution**

Modify Ed-Fi Docker images so that the SSL mount is optional