### PR TITLE
[AA-1585] Admin App 3.0 Release

### DIFF
--- a/DB-Admin/Alpine/pgsql/Dockerfile
+++ b/DB-Admin/Alpine/pgsql/Dockerfile
@@ -13,7 +13,7 @@ ENV POSTGRES_DB=postgres
 
 ENV ADMIN_VERSION="6.0.110"
 ENV SECURITY_VERSION="6.0.126"
-ENV ADMINAPP_DATABASE_VERSION="2.4.37"
+ENV ADMINAPP_DATABASE_VERSION="3.0.0"
 
 COPY init-database.sh /docker-entrypoint-initdb.d/1-init-database.sh
 COPY run-adminapp-migrations.sh /docker-entrypoint-initdb.d/2-run-adminapp-migrations.sh

--- a/Web-Ods-AdminApp/Alpine/mssql/Dockerfile
+++ b/Web-Ods-AdminApp/Alpine/mssql/Dockerfile
@@ -7,7 +7,7 @@
 FROM mcr.microsoft.com/dotnet/aspnet@sha256:4e32cb869308e781e518f721b25bd26b3a91fb3e2100c6d29e72176f75417472
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
 
-ENV VERSION="2.4.37"
+ENV VERSION="3.0.0"
 ENV PGBOUNCER_LISTEN_PORT=6432
 ENV ADMINAPP_VIRTUAL_NAME=adminapp
 ENV API_MODE=SharedInstance

--- a/Web-Ods-AdminApp/Alpine/mssql/appsettings.template.json
+++ b/Web-Ods-AdminApp/Alpine/mssql/appsettings.template.json
@@ -30,6 +30,28 @@
     "Security": "Data Source=$SQLSERVER_ADMIN_DATASOURCE;Initial Catalog=EdFi_Security;User Id=$SQLSERVER_USER;Password=$SQLSERVER_PASSWORD;Application Name=EdFi.Ods.AdminApp;Integrated Security=false;",
     "ProductionOds": "Data Source=$SQLSERVER_ODS_DATASOURCE;Initial Catalog=EdFi_{0};User Id=$SQLSERVER_USER;Password=$SQLSERVER_PASSWORD;Application Name=EdFi.Ods.AdminApp;Integrated Security=false;"
   },
+  "IdentitySettings": {
+    "Type": "EntityFramework",
+    "OpenIdSettings": {
+        "AuthenticationScheme": "oidc",
+        "Authority": "",
+        "ClientId": "",
+        "ClientSecret": "",
+        "UserProfileUri": "",
+        "LoginProvider": "my-oidc-provider",
+        "ResponseType": "code id_token",
+        "RequireHttpsMetadata": false,
+        "SaveTokens": true,
+        "GetClaimsFromUserInfoEndpoint": true,
+        "Scopes": [ "openid", "email" ],
+        "ClaimTypeMappings": {
+            "NameClaimType": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name",
+            "IdentifierClaimType": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier",
+            "EmailClaimType": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
+            "RoleClaimType": "http://schemas.microsoft.com/ws/2008/06/identity/claims/role"
+        }
+    }
+  },
   "Log4NetCore": {
     "Log4NetConfigFileName": "./log4net.config"
   },

--- a/Web-Ods-AdminApp/Alpine/pgsql/Dockerfile
+++ b/Web-Ods-AdminApp/Alpine/pgsql/Dockerfile
@@ -7,7 +7,7 @@
 FROM mcr.microsoft.com/dotnet/aspnet@sha256:4e32cb869308e781e518f721b25bd26b3a91fb3e2100c6d29e72176f75417472
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
 
-ENV VERSION="2.4.37"
+ENV VERSION="3.0.0"
 ENV POSTGRES_PORT=5432
 ENV PGBOUNCER_LISTEN_PORT=6432
 ENV NPG_POOLING_ENABLED=false

--- a/Web-Ods-AdminApp/Alpine/pgsql/appsettings.template.json
+++ b/Web-Ods-AdminApp/Alpine/pgsql/appsettings.template.json
@@ -30,6 +30,28 @@
     "Security": "host=${ADMIN_POSTGRES_HOST};port=${POSTGRES_PORT};username=${POSTGRES_USER};password=${POSTGRES_PASSWORD};database=EdFi_Security;pooling=${NPG_POOLING_ENABLED};maximum pool size=${NPG_ADMIN_MAX_POOL_SIZE_SECURITY};application name=EdFi.Ods.AdminApp",
     "ProductionOds": "host=${ODS_POSTGRES_HOST};port=${POSTGRES_PORT};username=${POSTGRES_USER};password=${POSTGRES_PASSWORD};database=EdFi_{0};pooling=${NPG_POOLING_ENABLED};maximum pool size=${NPG_ADMIN_MAX_POOL_SIZE_ODS};application name=EdFi.Ods.AdminApp"
   },
+  "IdentitySettings": {
+    "Type": "EntityFramework",
+    "OpenIdSettings": {
+        "AuthenticationScheme": "oidc",
+        "Authority": "",
+        "ClientId": "",
+        "ClientSecret": "",
+        "UserProfileUri": "",
+        "LoginProvider": "my-oidc-provider",
+        "ResponseType": "code id_token",
+        "RequireHttpsMetadata": false,
+        "SaveTokens": true,
+        "GetClaimsFromUserInfoEndpoint": true,
+        "Scopes": [ "openid", "email" ],
+        "ClaimTypeMappings": {
+            "NameClaimType": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name",
+            "IdentifierClaimType": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier",
+            "EmailClaimType": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
+            "RoleClaimType": "http://schemas.microsoft.com/ws/2008/06/identity/claims/role"
+        }
+    }
+  },
   "Log4NetCore": {
     "Log4NetConfigFileName": "./log4net.config"
   },


### PR DESCRIPTION
Update packages for Admin App 3.0 which is compatible with ODS/API 6.

**Remarks**

- Admin App 3.0 is **not** backwards compatible with ODS/API versions 3.4 - 5.3. Compatibility is planned for version 3.1.
- Admin App 3.0 includes support for using Open ID Connect for authentication and authorization. While this is supported using the Docker image, we did not make any changes to this composition, outside of introducing the new appsettings into the template and setting the default to use the existing database-driven user management

_This is in draft until the 3.0.0 package is available on Azure Artifacts._