### PR TITLE
[ODS-5782] Authentication configuration for PgBouncer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,8 +27,8 @@ POSTGRES_PASSWORD=<password for default postgres user>
 # PGBOUNCER_LISTEN_PORT=<port for pg bouncer to listen to>
 
 # NOTE - By default, PgBouncer logs the configuration file which contains sensitive information such as the host database username and password.
-# The following configuration variable PGBOUNCER_QUIET="true" which will suppress this messaging.
-PGBOUNCER_QUIET="true"
+# The following configuration variable PGBOUNCER_EXTRA_FLAGS="--quiet" will suppress this messaging.
+PGBOUNCER_EXTRA_FLAGS="--quiet"
 
 # PostgreSQL client-side pooling. Consider only if not using PgBouncer (see repository README file for additional information)
 # NPG_POOLING_ENABLED=<Enables or disables client-side pooling (default: false)>

--- a/.env.example
+++ b/.env.example
@@ -20,8 +20,13 @@ POPULATED_KEY=<populated template key>
 POPULATED_SECRET=<populated template secret>
 
 # Credentials used to authenticate to Postgres DB,  only needed if using Postgres DB
+# Both are used to enable auth_file security in PGBouncer
 POSTGRES_USER=<default postgres database user>
 POSTGRES_PASSWORD=<password for default postgres user>
+
+# These variables will include the database and password in the connection string, allowing to have access to the databases in the PG server.
+PGBOUNCER_SET_DATABASE_USER: "yes"
+PGBOUNCER_SET_DATABASE_PASSWORD: "yes"
 
 # Port PgBouncer listens on, only needed if using Postgres DB, defaults to 6432
 # PGBOUNCER_LISTEN_PORT=<port for pg bouncer to listen to>

--- a/Compose-Generator/Alpine/templates/pgsql/template.mustache
+++ b/Compose-Generator/Alpine/templates/pgsql/template.mustache
@@ -118,11 +118,16 @@ services:
       retries: 3
 
   edfi_ods_{{token}}:
-    image: pgbouncer/pgbouncer
+    image: bitnami/pgbouncer
     environment:
-      DATABASES: "* = host = db-ods-{{token}} port=5432 user=${POSTGRES_USER} password=${POSTGRES_PASSWORD}"
-      PGBOUNCER_LISTEN_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
-      QUIET: ${PGBOUNCER_QUIET}
+      PGBOUNCER_DATABASE: "*"
+      PGBOUNCER_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
+      PGBOUNCER_EXTRA_FLAGS: ${PGBOUNCER_EXTRA_FLAGS}
+      POSTGRESQL_USER: "${POSTGRES_USER}"
+      POSTGRESQL_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRESQL_HOST: db-ods-{{token}}
+      PGBOUNCER_SET_DATABASE_USER: "yes"
+      PGBOUNCER_SET_DATABASE_PASSWORD: "yes"
     {{#pgBouncerPort}}
     ports:
       - "{{.}}:${PGBOUNCER_LISTEN_PORT:-6432}"
@@ -178,11 +183,16 @@ services:
       retries: 3
 
   pb-admin:
-    image: pgbouncer/pgbouncer
+    image: bitnami/pgbouncer
     environment:
-      DATABASES: "* = host = db-admin port=5432 user=${POSTGRES_USER} password=${POSTGRES_PASSWORD}"
-      PGBOUNCER_LISTEN_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
-      QUIET: ${PGBOUNCER_QUIET}
+      PGBOUNCER_DATABASE: "*"
+      PGBOUNCER_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
+      PGBOUNCER_EXTRA_FLAGS: ${PGBOUNCER_EXTRA_FLAGS}
+      POSTGRESQL_USER: "${POSTGRES_USER}"
+      POSTGRESQL_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRESQL_HOST: db-admin
+      PGBOUNCER_SET_DATABASE_USER: "yes"
+      PGBOUNCER_SET_DATABASE_PASSWORD: "yes"
     ports:
       - "5401:${PGBOUNCER_LISTEN_PORT:-6432}"
     restart: always

--- a/Compose/pgsql/compose-district-specific-env-build.example.yml
+++ b/Compose/pgsql/compose-district-specific-env-build.example.yml
@@ -96,11 +96,16 @@ services:
       retries: 3
 
   edfi_ods_255901:
-    image: pgbouncer/pgbouncer
+    image: bitnami/pgbouncer
     environment:
-      DATABASES: "* = host = db-ods-255901 port=5432 user=${POSTGRES_USER} password=${POSTGRES_PASSWORD}"
-      PGBOUNCER_LISTEN_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
-      QUIET: ${PGBOUNCER_QUIET}
+      PGBOUNCER_DATABASE: "*"
+      PGBOUNCER_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
+      PGBOUNCER_EXTRA_FLAGS: ${PGBOUNCER_EXTRA_FLAGS}
+      POSTGRESQL_USER: "${POSTGRES_USER}"
+      POSTGRESQL_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRESQL_HOST: db-ods-255901
+      PGBOUNCER_SET_DATABASE_USER: "yes"
+      PGBOUNCER_SET_DATABASE_PASSWORD: "yes"
     ports:
       - "5402:${PGBOUNCER_LISTEN_PORT:-6432}"
     restart: always
@@ -127,11 +132,16 @@ services:
       retries: 3
 
   edfi_ods_255902:
-    image: pgbouncer/pgbouncer
+    image: bitnami/pgbouncer
     environment:
-      DATABASES: "* = host = db-ods-255902 port=5432 user=${POSTGRES_USER} password=${POSTGRES_PASSWORD}"
-      PGBOUNCER_LISTEN_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
-      QUIET: ${PGBOUNCER_QUIET}
+      PGBOUNCER_DATABASE: "*"
+      PGBOUNCER_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
+      PGBOUNCER_EXTRA_FLAGS: ${PGBOUNCER_EXTRA_FLAGS}
+      POSTGRESQL_USER: "${POSTGRES_USER}"
+      POSTGRESQL_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRESQL_HOST: db-ods-255902
+      PGBOUNCER_SET_DATABASE_USER: "yes"
+      PGBOUNCER_SET_DATABASE_PASSWORD: "yes"
     ports:
       - "5403:${PGBOUNCER_LISTEN_PORT:-6432}"
     restart: always
@@ -178,11 +188,16 @@ services:
       retries: 3
 
   pb-admin:
-    image: pgbouncer/pgbouncer
+    image: bitnami/pgbouncer
     environment:
-      DATABASES: "* = host = db-admin port=5432 user=${POSTGRES_USER} password=${POSTGRES_PASSWORD}"
-      PGBOUNCER_LISTEN_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
-      QUIET: ${PGBOUNCER_QUIET}
+      PGBOUNCER_DATABASE: "*"
+      PGBOUNCER_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
+      PGBOUNCER_EXTRA_FLAGS: ${PGBOUNCER_EXTRA_FLAGS}
+      POSTGRESQL_USER: "${POSTGRES_USER}"
+      POSTGRESQL_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRESQL_HOST: db-admin
+      PGBOUNCER_SET_DATABASE_USER: "yes"
+      PGBOUNCER_SET_DATABASE_PASSWORD: "yes"
     ports:
       - "5401:${PGBOUNCER_LISTEN_PORT:-6432}"
     restart: always

--- a/Compose/pgsql/compose-district-specific-env.example.yml
+++ b/Compose/pgsql/compose-district-specific-env.example.yml
@@ -88,11 +88,16 @@ services:
       retries: 3
 
   edfi_ods_255901:
-    image: pgbouncer/pgbouncer
+    image: bitnami/pgbouncer
     environment:
-      DATABASES: "* = host = db-ods-255901 port=5432 user=${POSTGRES_USER} password=${POSTGRES_PASSWORD}"
-      PGBOUNCER_LISTEN_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
-      QUIET: ${PGBOUNCER_QUIET}
+      PGBOUNCER_DATABASE: "*"
+      PGBOUNCER_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
+      PGBOUNCER_EXTRA_FLAGS: ${PGBOUNCER_EXTRA_FLAGS}
+      POSTGRESQL_USER: "${POSTGRES_USER}"
+      POSTGRESQL_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRESQL_HOST: db-ods-255901
+      PGBOUNCER_SET_DATABASE_USER: "yes"
+      PGBOUNCER_SET_DATABASE_PASSWORD: "yes"
     ports:
       - "5402:${PGBOUNCER_LISTEN_PORT:-6432}"
     restart: always
@@ -117,11 +122,16 @@ services:
       retries: 3
 
   edfi_ods_255902:
-    image: pgbouncer/pgbouncer
+    image: bitnami/pgbouncer
     environment:
-      DATABASES: "* = host = db-ods-255902 port=5432 user=${POSTGRES_USER} password=${POSTGRES_PASSWORD}"
-      PGBOUNCER_LISTEN_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
-      QUIET: ${PGBOUNCER_QUIET}
+      PGBOUNCER_DATABASE: "*"
+      PGBOUNCER_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
+      PGBOUNCER_EXTRA_FLAGS: ${PGBOUNCER_EXTRA_FLAGS}
+      POSTGRESQL_USER: "${POSTGRES_USER}"
+      POSTGRESQL_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRESQL_HOST: db-ods-255902
+      PGBOUNCER_SET_DATABASE_USER: "yes"
+      PGBOUNCER_SET_DATABASE_PASSWORD: "yes"
     ports:
       - "5403:${PGBOUNCER_LISTEN_PORT:-6432}"
     restart: always
@@ -166,11 +176,16 @@ services:
       retries: 3
 
   pb-admin:
-    image: pgbouncer/pgbouncer
+    image: bitnami/pgbouncer
     environment:
-      DATABASES: "* = host = db-admin port=5432 user=${POSTGRES_USER} password=${POSTGRES_PASSWORD}"
-      PGBOUNCER_LISTEN_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
-      QUIET: ${PGBOUNCER_QUIET}
+      PGBOUNCER_DATABASE: "*"
+      PGBOUNCER_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
+      PGBOUNCER_EXTRA_FLAGS: ${PGBOUNCER_EXTRA_FLAGS}
+      POSTGRESQL_USER: "${POSTGRES_USER}"
+      POSTGRESQL_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRESQL_HOST: db-admin
+      PGBOUNCER_SET_DATABASE_USER: "yes"
+      PGBOUNCER_SET_DATABASE_PASSWORD: "yes"
     ports:
       - "5401:${PGBOUNCER_LISTEN_PORT:-6432}"
     restart: always

--- a/Compose/pgsql/compose-sandbox-env-build.yml
+++ b/Compose/pgsql/compose-sandbox-env-build.yml
@@ -154,11 +154,16 @@ services:
       retries: 3
 
   pb-admin:
-    image: pgbouncer/pgbouncer
+    image: bitnami/pgbouncer
     environment:
-      DATABASES: "* = host = db-admin port=5432 user=${POSTGRES_USER} password=${POSTGRES_PASSWORD}"
-      PGBOUNCER_LISTEN_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
-      QUIET: ${PGBOUNCER_QUIET}
+      PGBOUNCER_DATABASE: "*"
+      PGBOUNCER_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
+      PGBOUNCER_EXTRA_FLAGS: ${PGBOUNCER_EXTRA_FLAGS}
+      POSTGRESQL_USER: "${POSTGRES_USER}"
+      POSTGRESQL_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRESQL_HOST: db-admin
+      PGBOUNCER_SET_DATABASE_USER: "yes"
+      PGBOUNCER_SET_DATABASE_PASSWORD: "yes"
     ports:
       - "5401:${PGBOUNCER_LISTEN_PORT:-6432}"
     restart: always
@@ -167,11 +172,16 @@ services:
       - db-admin
 
   pb-ods:
-    image: pgbouncer/pgbouncer
+    image: bitnami/pgbouncer
     environment:
-      DATABASES: "* = host = db-ods port=5432 user=${POSTGRES_USER} password=${POSTGRES_PASSWORD}"
-      PGBOUNCER_LISTEN_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
-      QUIET: ${PGBOUNCER_QUIET}
+      PGBOUNCER_DATABASE: "*"
+      PGBOUNCER_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
+      PGBOUNCER_EXTRA_FLAGS: ${PGBOUNCER_EXTRA_FLAGS}
+      POSTGRESQL_USER: "${POSTGRES_USER}"
+      POSTGRESQL_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRESQL_HOST: db-ods
+      PGBOUNCER_SET_DATABASE_USER: "yes"
+      PGBOUNCER_SET_DATABASE_PASSWORD: "yes"
     ports:
       - "5402:${PGBOUNCER_LISTEN_PORT:-6432}"
     restart: always

--- a/Compose/pgsql/compose-sandbox-env.yml
+++ b/Compose/pgsql/compose-sandbox-env.yml
@@ -142,11 +142,16 @@ services:
       retries: 3
 
   pb-admin:
-    image: pgbouncer/pgbouncer
+    image: bitnami/pgbouncer
     environment:
-      DATABASES: "* = host = db-admin port=5432 user=${POSTGRES_USER} password=${POSTGRES_PASSWORD}"
-      PGBOUNCER_LISTEN_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
-      QUIET: ${PGBOUNCER_QUIET}
+      PGBOUNCER_DATABASE: "*"
+      PGBOUNCER_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
+      PGBOUNCER_EXTRA_FLAGS: ${PGBOUNCER_EXTRA_FLAGS}
+      POSTGRESQL_USER: "${POSTGRES_USER}"
+      POSTGRESQL_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRESQL_HOST: db-admin
+      PGBOUNCER_SET_DATABASE_USER: "yes"
+      PGBOUNCER_SET_DATABASE_PASSWORD: "yes"
     ports:
       - "5401:${PGBOUNCER_LISTEN_PORT:-6432}"
     restart: always
@@ -155,11 +160,16 @@ services:
       - db-admin
 
   pb-ods:
-    image: pgbouncer/pgbouncer
+    image: bitnami/pgbouncer
     environment:
-      DATABASES: "* = host = db-ods port=5432 user=${POSTGRES_USER} password=${POSTGRES_PASSWORD}"
-      PGBOUNCER_LISTEN_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
-      QUIET: ${PGBOUNCER_QUIET}
+      PGBOUNCER_DATABASE: "*"
+      PGBOUNCER_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
+      PGBOUNCER_EXTRA_FLAGS: ${PGBOUNCER_EXTRA_FLAGS}
+      POSTGRESQL_USER: "${POSTGRES_USER}"
+      POSTGRESQL_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRESQL_HOST: db-ods
+      PGBOUNCER_SET_DATABASE_USER: "yes"
+      PGBOUNCER_SET_DATABASE_PASSWORD: "yes"
     ports:
       - "5402:${PGBOUNCER_LISTEN_PORT:-6432}"
     restart: always

--- a/Compose/pgsql/compose-shared-instance-env-build.yml
+++ b/Compose/pgsql/compose-shared-instance-env-build.yml
@@ -128,11 +128,16 @@ services:
       retries: 3
 
   pb-admin:
-    image: pgbouncer/pgbouncer
+    image: bitnami/pgbouncer
     environment:
-      DATABASES: "* = host = db-admin port=5432 user=${POSTGRES_USER} password=${POSTGRES_PASSWORD}"
-      PGBOUNCER_LISTEN_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
-      QUIET: ${PGBOUNCER_QUIET}
+      PGBOUNCER_DATABASE: "*"
+      PGBOUNCER_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
+      PGBOUNCER_EXTRA_FLAGS: ${PGBOUNCER_EXTRA_FLAGS}
+      POSTGRESQL_USER: "${POSTGRES_USER}"
+      POSTGRESQL_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRESQL_HOST: db-admin
+      PGBOUNCER_SET_DATABASE_USER: "yes"
+      PGBOUNCER_SET_DATABASE_PASSWORD: "yes"
     ports:
       - "5401:${PGBOUNCER_LISTEN_PORT:-6432}"
     restart: always
@@ -141,11 +146,16 @@ services:
       - db-admin
 
   pb-ods:
-    image: pgbouncer/pgbouncer
+    image: bitnami/pgbouncer
     environment:
-      DATABASES: "* = host = db-ods port=5432 user=${POSTGRES_USER} password=${POSTGRES_PASSWORD}"
-      PGBOUNCER_LISTEN_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
-      QUIET: ${PGBOUNCER_QUIET}
+      PGBOUNCER_DATABASE: "*"
+      PGBOUNCER_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
+      PGBOUNCER_EXTRA_FLAGS: ${PGBOUNCER_EXTRA_FLAGS}
+      POSTGRESQL_USER: "${POSTGRES_USER}"
+      POSTGRESQL_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRESQL_HOST: db-ods
+      PGBOUNCER_SET_DATABASE_USER: "yes"
+      PGBOUNCER_SET_DATABASE_PASSWORD: "yes"
     ports:
       - "5402:${PGBOUNCER_LISTEN_PORT:-6432}"
     restart: always

--- a/Compose/pgsql/compose-shared-instance-env.yml
+++ b/Compose/pgsql/compose-shared-instance-env.yml
@@ -118,11 +118,16 @@ services:
       retries: 3
 
   pb-admin:
-    image: pgbouncer/pgbouncer
+    image: bitnami/pgbouncer
     environment:
-      DATABASES: "* = host = db-admin port=5432 user=${POSTGRES_USER} password=${POSTGRES_PASSWORD}"
-      PGBOUNCER_LISTEN_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
-      QUIET: ${PGBOUNCER_QUIET}
+      PGBOUNCER_DATABASE: "*"
+      PGBOUNCER_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
+      PGBOUNCER_EXTRA_FLAGS: ${PGBOUNCER_EXTRA_FLAGS}
+      POSTGRESQL_USER: "${POSTGRES_USER}"
+      POSTGRESQL_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRESQL_HOST: db-admin
+      PGBOUNCER_SET_DATABASE_USER: "yes"
+      PGBOUNCER_SET_DATABASE_PASSWORD: "yes"
     ports:
       - "5401:${PGBOUNCER_LISTEN_PORT:-6432}"
     restart: always
@@ -131,11 +136,16 @@ services:
       - db-admin
 
   pb-ods:
-    image: pgbouncer/pgbouncer
+    image: bitnami/pgbouncer
     environment:
-      DATABASES: "* = host = db-ods port=5432 user=${POSTGRES_USER} password=${POSTGRES_PASSWORD}"
-      PGBOUNCER_LISTEN_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
-      QUIET: ${PGBOUNCER_QUIET}
+      PGBOUNCER_DATABASE: "*"
+      PGBOUNCER_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
+      PGBOUNCER_EXTRA_FLAGS: ${PGBOUNCER_EXTRA_FLAGS}
+      POSTGRESQL_USER: "${POSTGRES_USER}"
+      POSTGRESQL_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRESQL_HOST: db-ods
+      PGBOUNCER_SET_DATABASE_USER: "yes"
+      PGBOUNCER_SET_DATABASE_PASSWORD: "yes"
     ports:
       - "5402:${PGBOUNCER_LISTEN_PORT:-6432}"
     restart: always

--- a/Compose/pgsql/compose-year-specific-env-build.example.yml
+++ b/Compose/pgsql/compose-year-specific-env-build.example.yml
@@ -96,11 +96,16 @@ services:
       retries: 3
 
   edfi_ods_2022:
-    image: pgbouncer/pgbouncer
+    image: bitnami/pgbouncer
     environment:
-      DATABASES: "* = host = db-ods-2022 port=5432 user=${POSTGRES_USER} password=${POSTGRES_PASSWORD}"
-      PGBOUNCER_LISTEN_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
-      QUIET: ${PGBOUNCER_QUIET}
+      PGBOUNCER_DATABASE: "*"
+      PGBOUNCER_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
+      PGBOUNCER_EXTRA_FLAGS: ${PGBOUNCER_EXTRA_FLAGS}
+      POSTGRESQL_USER: "${POSTGRES_USER}"
+      POSTGRESQL_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRESQL_HOST: db-ods-2022
+      PGBOUNCER_SET_DATABASE_USER: "yes"
+      PGBOUNCER_SET_DATABASE_PASSWORD: "yes"
     ports:
       - "5402:${PGBOUNCER_LISTEN_PORT:-6432}"
     restart: always
@@ -127,11 +132,16 @@ services:
       retries: 3
 
   edfi_ods_2023:
-    image: pgbouncer/pgbouncer
+    image: bitnami/pgbouncer
     environment:
-      DATABASES: "* = host = db-ods-2023 port=5432 user=${POSTGRES_USER} password=${POSTGRES_PASSWORD}"
-      PGBOUNCER_LISTEN_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
-      QUIET: ${PGBOUNCER_QUIET}
+      PGBOUNCER_DATABASE: "*"
+      PGBOUNCER_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
+      PGBOUNCER_EXTRA_FLAGS: ${PGBOUNCER_EXTRA_FLAGS}
+      POSTGRESQL_USER: "${POSTGRES_USER}"
+      POSTGRESQL_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRESQL_HOST: db-ods-2023
+      PGBOUNCER_SET_DATABASE_USER: "yes"
+      PGBOUNCER_SET_DATABASE_PASSWORD: "yes"
     ports:
       - "5403:${PGBOUNCER_LISTEN_PORT:-6432}"
     restart: always
@@ -178,11 +188,16 @@ services:
       retries: 3
 
   pb-admin:
-    image: pgbouncer/pgbouncer
+    image: bitnami/pgbouncer
     environment:
-      DATABASES: "* = host = db-admin port=5432 user=${POSTGRES_USER} password=${POSTGRES_PASSWORD}"
-      PGBOUNCER_LISTEN_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
-      QUIET: ${PGBOUNCER_QUIET}
+      PGBOUNCER_DATABASE: "*"
+      PGBOUNCER_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
+      PGBOUNCER_EXTRA_FLAGS: ${PGBOUNCER_EXTRA_FLAGS}
+      POSTGRESQL_USER: "${POSTGRES_USER}"
+      POSTGRESQL_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRESQL_HOST: db-admin
+      PGBOUNCER_SET_DATABASE_USER: "yes"
+      PGBOUNCER_SET_DATABASE_PASSWORD: "yes"
     ports:
       - "5401:${PGBOUNCER_LISTEN_PORT:-6432}"
     restart: always

--- a/Compose/pgsql/compose-year-specific-env.example.yml
+++ b/Compose/pgsql/compose-year-specific-env.example.yml
@@ -88,11 +88,16 @@ services:
       retries: 3
 
   edfi_ods_2022:
-    image: pgbouncer/pgbouncer
+    image: bitnami/pgbouncer
     environment:
-      DATABASES: "* = host = db-ods-2022 port=5432 user=${POSTGRES_USER} password=${POSTGRES_PASSWORD}"
-      PGBOUNCER_LISTEN_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
-      QUIET: ${PGBOUNCER_QUIET}
+      PGBOUNCER_DATABASE: "*"
+      PGBOUNCER_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
+      PGBOUNCER_EXTRA_FLAGS: ${PGBOUNCER_EXTRA_FLAGS}
+      POSTGRESQL_USER: "${POSTGRES_USER}"
+      POSTGRESQL_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRESQL_HOST: db-ods-2022
+      PGBOUNCER_SET_DATABASE_USER: "yes"
+      PGBOUNCER_SET_DATABASE_PASSWORD: "yes"
     ports:
       - "5402:${PGBOUNCER_LISTEN_PORT:-6432}"
     restart: always
@@ -117,11 +122,16 @@ services:
       retries: 3
 
   edfi_ods_2023:
-    image: pgbouncer/pgbouncer
+    image: bitnami/pgbouncer
     environment:
-      DATABASES: "* = host = db-ods-2023 port=5432 user=${POSTGRES_USER} password=${POSTGRES_PASSWORD}"
-      PGBOUNCER_LISTEN_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
-      QUIET: ${PGBOUNCER_QUIET}
+      PGBOUNCER_DATABASE: "*"
+      PGBOUNCER_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
+      PGBOUNCER_EXTRA_FLAGS: ${PGBOUNCER_EXTRA_FLAGS}
+      POSTGRESQL_USER: "${POSTGRES_USER}"
+      POSTGRESQL_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRESQL_HOST: db-ods-2023
+      PGBOUNCER_SET_DATABASE_USER: "yes"
+      PGBOUNCER_SET_DATABASE_PASSWORD: "yes"
     ports:
       - "5403:${PGBOUNCER_LISTEN_PORT:-6432}"
     restart: always
@@ -166,11 +176,16 @@ services:
       retries: 3
 
   pb-admin:
-    image: pgbouncer/pgbouncer
+    image: bitnami/pgbouncer
     environment:
-      DATABASES: "* = host = db-admin port=5432 user=${POSTGRES_USER} password=${POSTGRES_PASSWORD}"
-      PGBOUNCER_LISTEN_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
-      QUIET: ${PGBOUNCER_QUIET}
+      PGBOUNCER_DATABASE: "*"
+      PGBOUNCER_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
+      PGBOUNCER_EXTRA_FLAGS: ${PGBOUNCER_EXTRA_FLAGS}
+      POSTGRESQL_USER: "${POSTGRES_USER}"
+      POSTGRESQL_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRESQL_HOST: db-admin
+      PGBOUNCER_SET_DATABASE_USER: "yes"
+      PGBOUNCER_SET_DATABASE_PASSWORD: "yes"
     ports:
       - "5401:${PGBOUNCER_LISTEN_PORT:-6432}"
     restart: always

--- a/README.md
+++ b/README.md
@@ -49,9 +49,13 @@ pb-ods:
 ### Supported environment variables
 [.env.example](.env.example) file included in the repository lists the supported environment variables.
 
+### PGBouncer security
+Variables ```POSTGRESQL_USER: "${POSTGRES_USER}"``` and ```POSTGRESQL_PASSWORD: "${POSTGRES_PASSWORD}"``` set the security to use an auth_file. Connections done through an exposed pgbouncer port will require a valid user and password.
+Variables ```PGBOUNCER_SET_DATABASE_USER: "yes"``` and ```PGBOUNCER_SET_DATABASE_PASSWORD: "yes"``` will include the database and password in the connection string, allowing to have access to the databases in the PG server.
+
 ### PGBouncer logging
 By default, PgBouncer logs the configuration file which contains sensitive information such as the host database username and password.  
-This functionality can be disabled by applying the QUIET flag. The latest version of .env.example has the configuration variable ```PGBOUNCER_QUIET="true"``` which will suppress this
+This functionality can be disabled by applying the QUIET flag. The latest version of .env.example has the configuration variable ```PGBOUNCER_EXTRA_FLAGS="--quiet"``` which will suppress this
 messaging.  However, older .env files that do not supply the PGBOUNCER\_QUIET configuration variable are still at risk of exposing this sensitive information in logs.
 
 ### Connection Pooling Options

--- a/README.md
+++ b/README.md
@@ -8,10 +8,16 @@ The compose files expose the databases outside of the Docker network (through Pg
 
 ```yaml
 pb-ods:
-  image: pgbouncer/pgbouncer
+  image: bitnami/pgbouncer
   environment:
-    DATABASES: "* = host = db-ods port=5432 user=${POSTGRES_USER} password=${POSTGRES_PASSWORD}"
-    PGBOUNCER_LISTEN_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
+      PGBOUNCER_DATABASE: "*"
+      PGBOUNCER_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
+      PGBOUNCER_EXTRA_FLAGS: ${PGBOUNCER_EXTRA_FLAGS}
+      POSTGRESQL_USER: "${POSTGRES_USER}"
+      POSTGRESQL_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRESQL_HOST: db-ods
+      PGBOUNCER_SET_DATABASE_USER: "yes"
+      PGBOUNCER_SET_DATABASE_PASSWORD: "yes"
   ports:
     - "5402:${PGBOUNCER_LISTEN_PORT:-6432}"
   restart: always
@@ -24,10 +30,16 @@ would be changed to:
 
 ```yaml
 pb-ods:
-  image: pgbouncer/pgbouncer
+  image: bitnami/pgbouncer
   environment:
-    DATABASES: "* = host = db-ods port=5432 user=${POSTGRES_USER} password=${POSTGRES_PASSWORD}"
-    PGBOUNCER_LISTEN_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
+      PGBOUNCER_DATABASE: "*"
+      PGBOUNCER_PORT: "${PGBOUNCER_LISTEN_PORT:-6432}"
+      PGBOUNCER_EXTRA_FLAGS: ${PGBOUNCER_EXTRA_FLAGS}
+      POSTGRESQL_USER: "${POSTGRES_USER}"
+      POSTGRESQL_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRESQL_HOST: db-ods
+      PGBOUNCER_SET_DATABASE_USER: "yes"
+      PGBOUNCER_SET_DATABASE_PASSWORD: "yes"
   restart: always
   container_name: ed-fi-pb-ods
   depends_on:

--- a/Web-Ods-AdminApp/Alpine/pgsql/Dockerfile
+++ b/Web-Ods-AdminApp/Alpine/pgsql/Dockerfile
@@ -23,7 +23,7 @@ COPY appsettings.template.json /app/appsettings.template.json
 COPY run.sh /app/run.sh
 COPY log4net.config /app/log4net.txt
 
-RUN apk --no-cache add unzip=~6 dos2unix=~7 bash=~5 gettext=~0 postgresql13-client=~13 jq=~1 icu=~71 curl=~7 && \
+RUN apk --no-cache add unzip=~6 dos2unix=~7 bash=~5 gettext=~0 postgresql13-client=~13 jq=~1 icu=~71 curl=~8 && \
     wget -O /app/AdminApp.zip  https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.Suite3.ODS.AdminApp.Web/versions/${VERSION}/content && \
     unzip /app/AdminApp.zip AdminApp/* -d /app/ && \
     cp -r /app/AdminApp/. /app/ && \

--- a/Web-Ods-Api/Alpine/pgsql/Dockerfile
+++ b/Web-Ods-Api/Alpine/pgsql/Dockerfile
@@ -23,7 +23,7 @@ COPY appsettings.template.json /app/appsettings.template.json
 COPY run.sh /app/run.sh
 COPY log4net.config /app/log4net.txt
 
-RUN apk --no-cache add unzip=~6 dos2unix=~7 bash=~5 gettext=~0 postgresql13-client=~13 icu=~71 curl=~7 && \
+RUN apk --no-cache add unzip=~6 dos2unix=~7 bash=~5 gettext=~0 postgresql13-client=~13 icu=~71 curl=~8 && \
     wget -O /app/WebApi.zip https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.Suite3.Ods.WebApi/versions/${VERSION}/content && \
     unzip /app/WebApi.zip -d /app && \
     rm -f /app/WebApi.zip && \

--- a/Web-Sandbox-Admin/Alpine/pgsql/Dockerfile
+++ b/Web-Sandbox-Admin/Alpine/pgsql/Dockerfile
@@ -24,7 +24,7 @@ COPY appsettings.template.json /app/appsettings.template.json
 COPY run.sh /app/run.sh
 COPY log4net.config /app/log4net.txt
 
-RUN apk --no-cache add unzip=~6 dos2unix=~7 bash=~5 gettext=~0 postgresql13-client=~13 icu=~71 curl=~7 && \
+RUN apk --no-cache add unzip=~6 dos2unix=~7 bash=~5 gettext=~0 postgresql13-client=~13 icu=~71 curl=~8 && \
     wget -O /app/SandboxAdmin.zip https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.Suite3.Ods.SandboxAdmin/versions/${VERSION}/content && \
     unzip /app/SandboxAdmin.zip -d /app && \
     rm -f /app/SandboxAdmin.zip && \

--- a/Web-SwaggerUI/Alpine/Dockerfile
+++ b/Web-SwaggerUI/Alpine/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /app
 COPY appsettings.template.json /app/appsettings.template.json
 COPY run.sh /app/run.sh
 
-RUN apk --no-cache add unzip=~6 dos2unix=~7 bash=~5 gettext=~0 icu=~71 curl=~7 && \
+RUN apk --no-cache add unzip=~6 dos2unix=~7 bash=~5 gettext=~0 icu=~71 curl=~8 && \
     wget -O /app/SwaggerUI.zip https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.Suite3.Ods.SwaggerUI/versions/${VERSION}/content && \
     unzip /app/SwaggerUI.zip -d /app && \
     rm -f /app/SwaggerUI.zip && \


### PR DESCRIPTION
Variables ```POSTGRESQL_USER: "${POSTGRES_USER}"``` and ```POSTGRESQL_PASSWORD: "${POSTGRES_PASSWORD}"``` set the security to use an auth_file. Connections done through an exposed pgbouncer port will require a valid user and password.

Variables ```PGBOUNCER_SET_DATABASE_USER: "yes"``` and ```PGBOUNCER_SET_DATABASE_PASSWORD: "yes"``` will include the database and password in the connection string, allowing to have access to the databases in the PG server.