### PR TITLE
[ODS-6119] Switch Web-Gateway base image to unprivileged nginx image

### DIFF
--- a/Compose-Generator/Alpine/templates/pgsql/MultiTenant-OdsContext/compose-template.mustache
+++ b/Compose-Generator/Alpine/templates/pgsql/MultiTenant-OdsContext/compose-template.mustache
@@ -90,7 +90,7 @@ services:
       ODS_VIRTUAL_NAME: "${ODS_VIRTUAL_NAME:-api}"
     ports:
       - "443:443"
-      - "80:80"
+      - "80:8080"
     container_name: ed-fi-gateway
     restart: always
     hostname: nginx

--- a/Compose-Generator/Alpine/templates/pgsql/MultiTenant-OdsContext/compose-template.mustache
+++ b/Compose-Generator/Alpine/templates/pgsql/MultiTenant-OdsContext/compose-template.mustache
@@ -90,7 +90,6 @@ services:
       ODS_VIRTUAL_NAME: "${ODS_VIRTUAL_NAME:-api}"
     ports:
       - "443:443"
-      - "80:8080"
     container_name: ed-fi-gateway
     restart: always
     hostname: nginx

--- a/Compose-Generator/Alpine/templates/pgsql/MultiTenant/compose-template.mustache
+++ b/Compose-Generator/Alpine/templates/pgsql/MultiTenant/compose-template.mustache
@@ -51,7 +51,6 @@ services:
       ODS_VIRTUAL_NAME: "${ODS_VIRTUAL_NAME:-api}"
     ports:
       - "443:443"
-      - "80:8080"
     container_name: ed-fi-gateway
     restart: always
     hostname: nginx

--- a/Compose-Generator/Alpine/templates/pgsql/MultiTenant/compose-template.mustache
+++ b/Compose-Generator/Alpine/templates/pgsql/MultiTenant/compose-template.mustache
@@ -51,7 +51,7 @@ services:
       ODS_VIRTUAL_NAME: "${ODS_VIRTUAL_NAME:-api}"
     ports:
       - "443:443"
-      - "80:80"
+      - "80:8080"
     container_name: ed-fi-gateway
     restart: always
     hostname: nginx

--- a/Compose-Generator/Alpine/templates/pgsql/SingleTenant-OdsContext/compose-template.mustache
+++ b/Compose-Generator/Alpine/templates/pgsql/SingleTenant-OdsContext/compose-template.mustache
@@ -30,7 +30,7 @@ services:
       ODS_VIRTUAL_NAME: "${ODS_VIRTUAL_NAME:-api}"
     ports:
       - "443:443"
-      - "80:80"
+      - "80:8080"
     container_name: ed-fi-gateway
     restart: always
     hostname: nginx

--- a/Compose-Generator/Alpine/templates/pgsql/SingleTenant-OdsContext/compose-template.mustache
+++ b/Compose-Generator/Alpine/templates/pgsql/SingleTenant-OdsContext/compose-template.mustache
@@ -30,7 +30,6 @@ services:
       ODS_VIRTUAL_NAME: "${ODS_VIRTUAL_NAME:-api}"
     ports:
       - "443:443"
-      - "80:8080"
     container_name: ed-fi-gateway
     restart: always
     hostname: nginx

--- a/Compose/mssql/compose-sandbox-env.yml
+++ b/Compose/mssql/compose-sandbox-env.yml
@@ -13,7 +13,6 @@ services:
       SANDBOX_ADMIN_VIRTUAL_NAME: "${SANDBOX_ADMIN_VIRTUAL_NAME:-admin}"
     ports:
       - "443:443"
-      - "80:8080"
     container_name: ed-fi-gateway
     restart: always
     hostname: nginx

--- a/Compose/mssql/compose-sandbox-env.yml
+++ b/Compose/mssql/compose-sandbox-env.yml
@@ -13,7 +13,7 @@ services:
       SANDBOX_ADMIN_VIRTUAL_NAME: "${SANDBOX_ADMIN_VIRTUAL_NAME:-admin}"
     ports:
       - "443:443"
-      - "80:80"
+      - "80:8080"
     container_name: ed-fi-gateway
     restart: always
     hostname: nginx

--- a/Compose/mssql/compose-single-tenant-env.yml
+++ b/Compose/mssql/compose-single-tenant-env.yml
@@ -12,7 +12,7 @@ services:
       ODS_VIRTUAL_NAME: "${ODS_VIRTUAL_NAME:-api}"
     ports:
       - "443:443"
-      - "80:80"
+      - "80:8080"
     container_name: ed-fi-gateway
     restart: always
     hostname: nginx

--- a/Compose/mssql/compose-single-tenant-env.yml
+++ b/Compose/mssql/compose-single-tenant-env.yml
@@ -12,7 +12,6 @@ services:
       ODS_VIRTUAL_NAME: "${ODS_VIRTUAL_NAME:-api}"
     ports:
       - "443:443"
-      - "80:8080"
     container_name: ed-fi-gateway
     restart: always
     hostname: nginx

--- a/Compose/pgsql/MultiTenant-OdsContext/compose-multi-tenant-odscontext-env.yml
+++ b/Compose/pgsql/MultiTenant-OdsContext/compose-multi-tenant-odscontext-env.yml
@@ -216,7 +216,7 @@ services:
       ODS_VIRTUAL_NAME: "${ODS_VIRTUAL_NAME:-api}"
     ports:
       - "443:443"
-      - "80:80"
+      - "80:8080"
     container_name: ed-fi-gateway
     restart: always
     hostname: nginx

--- a/Compose/pgsql/MultiTenant-OdsContext/compose-multi-tenant-odscontext-env.yml
+++ b/Compose/pgsql/MultiTenant-OdsContext/compose-multi-tenant-odscontext-env.yml
@@ -216,7 +216,6 @@ services:
       ODS_VIRTUAL_NAME: "${ODS_VIRTUAL_NAME:-api}"
     ports:
       - "443:443"
-      - "80:8080"
     container_name: ed-fi-gateway
     restart: always
     hostname: nginx

--- a/Compose/pgsql/MultiTenant/compose-multi-tenant-env.yml
+++ b/Compose/pgsql/MultiTenant/compose-multi-tenant-env.yml
@@ -82,7 +82,6 @@ services:
       ODS_VIRTUAL_NAME: "${ODS_VIRTUAL_NAME:-api}"
     ports:
       - "443:443"
-      - "80:8080"
     container_name: ed-fi-gateway
     restart: always
     hostname: nginx

--- a/Compose/pgsql/MultiTenant/compose-multi-tenant-env.yml
+++ b/Compose/pgsql/MultiTenant/compose-multi-tenant-env.yml
@@ -82,7 +82,7 @@ services:
       ODS_VIRTUAL_NAME: "${ODS_VIRTUAL_NAME:-api}"
     ports:
       - "443:443"
-      - "80:80"
+      - "80:8080"
     container_name: ed-fi-gateway
     restart: always
     hostname: nginx

--- a/Compose/pgsql/SingleTenant-OdsContext/compose-single-tenant-odscontext-env.yml
+++ b/Compose/pgsql/SingleTenant-OdsContext/compose-single-tenant-odscontext-env.yml
@@ -30,7 +30,7 @@ services:
       ODS_VIRTUAL_NAME: "${ODS_VIRTUAL_NAME:-api}"
     ports:
       - "443:443"
-      - "80:80"
+      - "80:8080"
     container_name: ed-fi-gateway
     restart: always
     hostname: nginx

--- a/Compose/pgsql/SingleTenant-OdsContext/compose-single-tenant-odscontext-env.yml
+++ b/Compose/pgsql/SingleTenant-OdsContext/compose-single-tenant-odscontext-env.yml
@@ -30,7 +30,6 @@ services:
       ODS_VIRTUAL_NAME: "${ODS_VIRTUAL_NAME:-api}"
     ports:
       - "443:443"
-      - "80:8080"
     container_name: ed-fi-gateway
     restart: always
     hostname: nginx

--- a/Compose/pgsql/SingleTenant/compose-single-tenant-env.yml
+++ b/Compose/pgsql/SingleTenant/compose-single-tenant-env.yml
@@ -45,7 +45,7 @@ services:
       ODS_VIRTUAL_NAME: "${ODS_VIRTUAL_NAME:-api}"
     ports:
       - "443:443"
-      - "80:80"
+      - "80:8080"
     container_name: ed-fi-gateway
     restart: always
     hostname: nginx

--- a/Compose/pgsql/SingleTenant/compose-single-tenant-env.yml
+++ b/Compose/pgsql/SingleTenant/compose-single-tenant-env.yml
@@ -45,7 +45,6 @@ services:
       ODS_VIRTUAL_NAME: "${ODS_VIRTUAL_NAME:-api}"
     ports:
       - "443:443"
-      - "80:8080"
     container_name: ed-fi-gateway
     restart: always
     hostname: nginx

--- a/Compose/pgsql/compose-sandbox-env.yml
+++ b/Compose/pgsql/compose-sandbox-env.yml
@@ -42,7 +42,6 @@ services:
       SANDBOX_ADMIN_VIRTUAL_NAME: "${SANDBOX_ADMIN_VIRTUAL_NAME:-admin}"
     ports:
       - "443:443"
-      - "80:8080"
     container_name: ed-fi-gateway
     restart: always
     hostname: nginx

--- a/Compose/pgsql/compose-sandbox-env.yml
+++ b/Compose/pgsql/compose-sandbox-env.yml
@@ -42,7 +42,7 @@ services:
       SANDBOX_ADMIN_VIRTUAL_NAME: "${SANDBOX_ADMIN_VIRTUAL_NAME:-admin}"
     ports:
       - "443:443"
-      - "80:80"
+      - "80:8080"
     container_name: ed-fi-gateway
     restart: always
     hostname: nginx

--- a/Web-Gateway-Sandbox/Alpine/Dockerfile
+++ b/Web-Gateway-Sandbox/Alpine/Dockerfile
@@ -3,8 +3,8 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
-# Tag nginx:1.25.1-alpine3.17
-FROM nginx:1.25.1-alpine3.17@sha256:647c5c83418c19eef0cddc647b9899326e3081576390c4c7baa4fce545123b6c
+# Base image
+FROM nginxinc/nginx-unprivileged:1.25.3-alpine3.18@sha256:fa82525b9e33387b17d560ea9a40b1bdcb1816df55af7a7597ebfb55f2a8c56b
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
 
 ENV ODS_VIRTUAL_NAME=api

--- a/Web-Gateway/Alpine/Dockerfile
+++ b/Web-Gateway/Alpine/Dockerfile
@@ -3,8 +3,8 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
-# Tag nginx:1.25.1-alpine3.17
-FROM nginx:1.25.1-alpine3.17@sha256:647c5c83418c19eef0cddc647b9899326e3081576390c4c7baa4fce545123b6c
+# Base image
+FROM nginxinc/nginx-unprivileged:1.25.3-alpine3.18@sha256:fa82525b9e33387b17d560ea9a40b1bdcb1816df55af7a7597ebfb55f2a8c56b
 LABEL maintainer="Ed-Fi Alliance, LLC and Contributors <techsupport@ed-fi.org>"
 
 ENV ODS_VIRTUAL_NAME=api


### PR DESCRIPTION
Web-Gateway containers now are executed as nginx user 
![image](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Docker/assets/43448209/a431abdb-26eb-4888-9988-27f2abf49d97)
