### PR TITLE
[ODS-6499] Fix 6.x docker images to work as non-root users

### DIFF
--- a/Web-Ods-Api/Alpine/mssql/Dockerfile
+++ b/Web-Ods-Api/Alpine/mssql/Dockerfile
@@ -37,6 +37,6 @@ RUN umask 0077 && \
     apk del unzip dos2unix curl && \
     chown -R edfi /app
 
-EXPOSE ${ASPNETCORE_HTTP_PORTS}
+EXPOSE 80
 USER edfi
 ENTRYPOINT ["/app/run.sh"]

--- a/Web-Sandbox-Admin/Alpine/mssql/Dockerfile
+++ b/Web-Sandbox-Admin/Alpine/mssql/Dockerfile
@@ -43,6 +43,6 @@ RUN umask 0077 && \
     apk del unzip dos2unix curl && \
     chown -R edfi /app
 
-EXPOSE ${ASPNETCORE_HTTP_PORTS}
+EXPOSE 80
 USER edfi
 ENTRYPOINT ["/app/run.sh"]

--- a/Web-Sandbox-Admin/Alpine/mssql/appsettings.template.json
+++ b/Web-Sandbox-Admin/Alpine/mssql/appsettings.template.json
@@ -55,6 +55,5 @@
   "ApiSettings": {
     "Engine": "SQLServer",
     "UseReverseProxyHeaders": true
-  },
-  "Urls": "http://0.0.0.0:80"
+  }
 }

--- a/Web-Sandbox-Admin/Alpine/pgsql/appsettings.template.json
+++ b/Web-Sandbox-Admin/Alpine/pgsql/appsettings.template.json
@@ -55,6 +55,5 @@
   "ApiSettings": {
     "Engine": "PostgreSQL",
     "UseReverseProxyHeaders": true
-  },
-  "Urls": "http://0.0.0.0:80"
+  }
 }

--- a/Web-SwaggerUI/Alpine/Dockerfile
+++ b/Web-SwaggerUI/Alpine/Dockerfile
@@ -38,6 +38,6 @@ RUN umask 0077 && \
     apk del unzip dos2unix curl && \
     chown -R edfi /app
 
-EXPOSE ${ASPNETCORE_HTTP_PORTS}
+EXPOSE 80
 USER edfi
 ENTRYPOINT ["/app/run.sh"]

--- a/Web-SwaggerUI/Alpine/appsettings.template.json
+++ b/Web-SwaggerUI/Alpine/appsettings.template.json
@@ -11,6 +11,5 @@
       "ClientSecret": "$POPULATED_SECRET",
       "ClientId": "$POPULATED_KEY"
     }
-  },
-  "Urls": "http://0.0.0.0:80"
+  }
 }


### PR DESCRIPTION
For testing purpose update in compose-sandbox-env-build file 

you need add ASPNETCORE_HTTP_PORTS: "8080" in under  environment: for api: ,   sandbox-admin:  &  swagger:

you need add ports for api :

    ports:
      - "81:8080"     

you need add ports for sandbox-admin:

    ports:
      - "82:8080"     
you need add ports for swagger:

    ports:
      - "83:8080"     
![image](https://github.com/user-attachments/assets/d8e71bb4-63e5-4ece-8e4a-fd2d566f2f84)
![image](https://github.com/user-attachments/assets/91b4ea16-c843-4ff6-aa05-682dab721332)
![image](https://github.com/user-attachments/assets/9c98551b-1a67-43f3-bb83-d03a30ef3414)


